### PR TITLE
opensuse.dsc

### DIFF
--- a/py2pack/templates/opensuse.dsc
+++ b/py2pack/templates/opensuse.dsc
@@ -1,21 +1,5 @@
-#
-# dsc file for package python-{{ name|lower }}
-#
-# Copyright (c) {{ year }} {{ user_name }}.
-#
-# All modifications and additions to the file contributed by third parties
-# remain the property of their copyright owners, unless otherwise agreed
-# upon. The license for this file, and modifications and additions to the
-# file, is the same license as for the pristine package itself (unless the
-# license for the pristine package is not an Open Source License, in which
-# case the license is the MIT License). An "Open Source License" is a
-# license that conforms to the Open Source Definition (Version 1.9)
-# published by the Open Source Initiative.
-
-# Please submit bugfixes or comments via http://bugs.opensuse.org/
-
 Format: 1.0
-Source: {{ source_url }}
+Source: {{ name }}
 Version: {{ version }}
 Binary: python-{{ name|lower }}
 Maintainer: {{ user_name }}


### PR DESCRIPTION
- removed license, breaks building (We talked about it on osc11)
- just use name in source, because source_url breaks also building
