### PR TITLE
Update repository name after move to openSUSE

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,4 +20,4 @@ deploy:
   on:
     tags: true
     distributions: sdist bdist_wheel
-    repo: saschpe/py2pack
+    repo: openSUSE/py2pack

--- a/README.rst
+++ b/README.rst
@@ -1,8 +1,8 @@
 Py2pack: Generate distribution packages from PyPI
 =================================================
 
-.. image:: https://travis-ci.org/saschpe/py2pack.png?branch=master
-        :target: https://travis-ci.org/saschpe/py2pack
+.. image:: https://travis-ci.org/openSUSE/py2pack.png?branch=master
+        :target: https://travis-ci.org/openSUSE/py2pack
 
 
 This script allows to generate RPM spec or DEB dsc files from Python modules.
@@ -129,7 +129,7 @@ on your system.
 .. _DEB: http://en.wikipedia.org/wiki/Deb_(file_format)
 .. _`Python Package Index`: https://pypi.python.org/pypi/rapport
 .. _`Open Build Service`: https://build.opensuse.org/package/show?package=rapport&project=devel:languages:python
-.. _`the repository`: https://github.com/saschpe/py2pack
+.. _`the repository`: https://github.com/openSUSE/py2pack
 .. _`nose`: https://nose.readthedocs.org
 .. _`tox`: http://testrun.org/tox
 

--- a/doc/src/py2pack.xml.in
+++ b/doc/src/py2pack.xml.in
@@ -38,7 +38,7 @@
     <manvolnum>1</manvolnum>
     <refmiscinfo class="version">@VERSION@</refmiscinfo>
     <refmiscinfo class="source"
-      >http://github.com/saschpe/py2pack</refmiscinfo>
+      >http://github.com/openSUSE/py2pack</refmiscinfo>
     <!--<refmiscinfo class="manual"></refmiscinfo>-->
   </refmeta>
 

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
     long_description=long_description,
     author=py2pack.__author__.rsplit(' ', 1)[0],
     author_email=py2pack.__author__.rsplit(' ', 1)[1][1:-1],
-    url='http://github.com/saschpe/py2pack',
+    url='http://github.com/openSUSE/py2pack',
     scripts=['scripts/py2pack'],
     packages=['py2pack'],
     package_data={'py2pack': ['templates/*', 'spdx_license_map.p']},


### PR DESCRIPTION
py2pack recently moved from http://github.com/saschpe/py2pack to
http://github.com/openSUSE/py2pack .