### PR TITLE
Ignore the required python version for now

### DIFF
--- a/py2pack/templates/opensuse.spec
+++ b/py2pack/templates/opensuse.spec
@@ -26,7 +26,7 @@ Url:            {{ home_page }}
 Group:          Development/Languages/Python
 Source:         {{ source_url|replace(version, '%{version}') }}
 BuildRequires:  python-rpm-macros
-BuildRequires:  %{python_module devel} {%- if requires_python %} = {{ requires_python }} {% endif %}
+BuildRequires:  %{python_module devel}
 BuildRequires:  %{python_module setuptools}
 {%- if setup_requires and setup_requires is not none %}
 {%- for req in setup_requires|sort %}


### PR DESCRIPTION
The required python version can be set in a setup.py file via
"python_requires". This needs proper parsing (strings like
'>=2.6,!=3.0.*,!=3.1.*,!=3.2.*' are possible) so ignore it for now.