### PR TITLE
Fix proxy

### DIFF
--- a/py2pack/__init__.py
+++ b/py2pack/__init__.py
@@ -28,8 +28,8 @@ import pprint
 import pwd
 import re
 import sys
-import urllib
-from six.moves.urllib.request import urlretrieve
+from six.moves.urllib import request as urllib
+from six.moves.urllib.parse import urlparse
 from six.moves import filter
 from six.moves import xmlrpc_client
 import jinja2
@@ -44,7 +44,7 @@ import py2pack.utils
 from py2pack import version as py2pack_version
 
 
-pypi = xmlrpc_client.ServerProxy('https://pypi.python.org/pypi')
+pypi = None
 
 SPDX_LICENSES_FILE = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'spdx_license_map.p')
 SDPX_LICENSES = pickle.load(open(SPDX_LICENSES_FILE, 'rb'))
@@ -90,7 +90,7 @@ def fetch(args):
         sys.exit(1)
     print('downloading package {0}-{1}...'.format(args.name, args.version))
     print('from {0}'.format(url['url']))
-    urlretrieve(url['url'], url['filename'])
+    urllib.urlretrieve(url['url'], url['filename'])
 
 
 def _canonicalize_setup_data(data):
@@ -320,16 +320,24 @@ def main():
 
     args = parser.parse_args()
 
+    transport = None
     # set HTTP proxy if one is provided
     if args.proxy:
+        url_parts = urlparse(args.proxy)
+
         try:
-            urllib.urlopen(args.proxy)
+            handler = urllib.ProxyHandler({'https': url_parts.geturl()})
+            opener = urllib.build_opener(handler)
+            opener.open('https://pypi.python.org/pypi')
         except IOError:
             print('the proxy \'{0}\' is not responding'.format(args.proxy))
             sys.exit(1)
+
         transport = py2pack.proxy.ProxiedTransport()
-        transport.set_proxy(args.proxy)
-        pypi._ServerProxy__transport = transport  # Evil, but should do the trick
+        transport.set_proxy(url_parts.hostname, port=url_parts.port)
+
+    global pypi
+    pypi = xmlrpc_client.ServerProxy('https://pypi.python.org/pypi', transport=transport)
 
     args.func(args)
 

--- a/py2pack/__init__.py
+++ b/py2pack/__init__.py
@@ -334,6 +334,8 @@ def main():
             handler = urllib.ProxyHandler({'https': url})
             opener = urllib.build_opener(handler)
             opener.open(PYPI_URL)
+
+            urllib.install_opener(opener)
         except IOError:
             print('the proxy \'{0}\' is not responding'.format(args.proxy))
             sys.exit(1)

--- a/py2pack/__init__.py
+++ b/py2pack/__init__.py
@@ -43,8 +43,9 @@ import py2pack.utils
 from py2pack import version as py2pack_version
 
 
-pypi_url = 'https://pypi.python.org/pypi'
-pypi = xmlrpc_client.ServerProxy(pypi_url)
+PYPI_URL = 'https://pypi.python.org/pypi'
+
+pypi = xmlrpc_client.ServerProxy(PYPI_URL)
 
 SPDX_LICENSES_FILE = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'spdx_license_map.p')
 SDPX_LICENSES = pickle.load(open(SPDX_LICENSES_FILE, 'rb'))
@@ -323,7 +324,6 @@ def main():
     # set HTTP proxy if one is provided
     if args.proxy:
         global pypi
-        global pypi_url
 
         # add schema to url if it is not there
         url = args.proxy
@@ -333,13 +333,13 @@ def main():
         try:
             handler = urllib.ProxyHandler({'https': url})
             opener = urllib.build_opener(handler)
-            opener.open(pypi_url)
+            opener.open(PYPI_URL)
         except IOError:
             print('the proxy \'{0}\' is not responding'.format(args.proxy))
             sys.exit(1)
 
         transport = py2pack.proxy.make_transport(url)
-        pypi = xmlrpc_client.ServerProxy(pypi_url, transport=transport)
+        pypi = xmlrpc_client.ServerProxy(PYPI_URL, transport=transport)
 
     args.func(args)
 

--- a/py2pack/__init__.py
+++ b/py2pack/__init__.py
@@ -284,7 +284,7 @@ def file_template_list():
 def main():
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument('--version', action='version', version='%(prog)s {0}'.format(py2pack_version.version))
-    parser.add_argument('--proxy', help='HTTP proxy to use')
+    parser.add_argument('--proxy', help='HTTP proxy to use', default=os.environ.get('https_proxy', None))
     subparsers = parser.add_subparsers(title='commands')
 
     parser_list = subparsers.add_parser('list', help='list all packages on PyPI')
@@ -323,7 +323,12 @@ def main():
     transport = None
     # set HTTP proxy if one is provided
     if args.proxy:
-        url_parts = urlparse(args.proxy)
+        # add schema to url if it is not there
+        url = args.proxy
+        if "//" not in url:
+            url = "//{}".format(url)
+
+        url_parts = urlparse(url)
 
         try:
             handler = urllib.ProxyHandler({'https': url_parts.geturl()})

--- a/py2pack/__init__.py
+++ b/py2pack/__init__.py
@@ -92,7 +92,9 @@ def fetch(args):
         sys.exit(1)
     print('downloading package {0}-{1}...'.format(args.name, args.version))
     print('from {0}'.format(url['url']))
-    urllib.urlretrieve(url['url'], url['filename'])
+    with open(url['filename'], 'wb') as f:
+        f.write(urllib.urlopen(url['url']).read())
+        f.close()
 
 
 def _canonicalize_setup_data(data):

--- a/py2pack/__init__.py
+++ b/py2pack/__init__.py
@@ -215,11 +215,8 @@ def _render(data, template, out_filename):
     env = _prepare_template_env(_get_template_dirs())
     template = env.get_template(template)
     result = template.render(data).encode('utf-8')  # render template and encode properly
-    outfile = open(out_filename, 'wb')  # write result to spec file
-    try:
+    with open(out_filename, 'wb') as outfile:       # write result to spec file
         outfile.write(result)
-    finally:
-        outfile.close()
 
 
 def generate(args):

--- a/py2pack/__init__.py
+++ b/py2pack/__init__.py
@@ -289,38 +289,21 @@ def generate_local(args):
     else:
         _license_from_classifiers(data)
 
-    if metadata.summary:
-        data['summary'] = metadata.summary
-
-    if metadata.description:
-        data['description'] = metadata.description
-
-    if metadata.author:
-        data['author'] = metadata.author
-
-    if metadata.author_email:
-        data['author_email'] = metadata.author_email
-
-    if metadata.download_url:
-        data['download_url'] = metadata.download_url
-
-    if metadata.home_page:
-        data['home_page'] = metadata.home_page
-
     if metadata.platforms:
         data['platform'] = ', '.join(metadata.platforms)
+    else:
+        data['platform'] = ''
 
-    if metadata.provides:
-        data['provides'] = metadata.provides
-
-    if metadata.requires:
-        data['requires'] = metadata.requires
-
-    if metadata.requires_dist:
-        data['requires_dist'] = metadata.requires_dist
-
-    if metadata.requires_external:
-        data['requires_external'] = metadata.requires_external
+    data['summary'] = metadata.summary
+    data['description'] = metadata.description
+    data['author'] = metadata.author
+    data['author_email'] = metadata.author_email
+    data['download_url'] = metadata.download_url
+    data['home_page'] = metadata.home_page
+    data['provides'] = metadata.provides
+    data['requires'] = metadata.requires
+    data['requires_dist'] = metadata.requires_dist
+    data['requires_external'] = metadata.requires_external
 
     if metadata.requires_python:
         data['requires_python'] = metadata.requires_python

--- a/py2pack/proxy.py
+++ b/py2pack/proxy.py
@@ -15,7 +15,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import six.moves.http_client as httplib
+from six.moves.urllib.parse import urlparse
 from six.moves import xmlrpc_client as xmlrpclib
+
+
+def make_transport(url):
+    url_parts = urlparse(url)
+
+    transport = ProxiedTransport()
+    transport.set_proxy(url_parts.hostname, port=url_parts.port)
+
+    return transport
 
 
 class ProxiedTransport(xmlrpclib.Transport):

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ Jinja2
 setuptools
 six
 metaextract
+pkginfo

--- a/setup.py
+++ b/setup.py
@@ -27,5 +27,5 @@ except ImportError:
     pass
 
 setuptools.setup(
-    setup_requires=['pbr>=1.8'],
+    setup_requires=['pkginfo', 'pbr>=1.8'],
     pbr=True)

--- a/setup.py
+++ b/setup.py
@@ -27,5 +27,5 @@ except ImportError:
     pass
 
 setuptools.setup(
-    setup_requires=['pkginfo', 'pbr>=1.8'],
+    setup_requires=['pbr>=1.8'],
     pbr=True)


### PR DESCRIPTION
I have a proxy server with non-default port which doesn't pass `urlopen` test (won't answer).

In this PR I fixed both problems.

- Proxy server default URL is read from environment variable `https_proxy`;
- Availability is checked by opening pypi via proxy server;
- ProxiedTransport is updated to match [example](https://docs.python.org/3.6/library/xmlrpc.client.html#example-of-client-usage);
- Py2/3 compatibility is improved by using more six.move imports.