### PR TITLE
Handle no upstream source download URL gracefully

### DIFF
--- a/py2pack/__init__.py
+++ b/py2pack/__init__.py
@@ -268,7 +268,7 @@ def newest_download_url(args):
             return url
     # No PyPI tarball release, let's see if an upstream download URL is provided:
     data = pypi.release_data(args.name, args.version)                       # Fetch all meta data
-    if 'download_url' in data:
+    if 'download_url' in data and data['download_url']:
         filename = os.path.basename(data['download_url'])
         return {'url': data['download_url'], 'filename': filename}
     return {}                                                               # We're all out of bubblegum


### PR DESCRIPTION
In case there is a upstream download URL but it is not pointing to a source
archive as for https://pypi.python.org/pypi/signedjson/ we are out of luck but
should not crash trying to parse a NoneType download URL.