### PR TITLE
Some small fixes including opensuse-multipython fix

### DIFF
--- a/py2pack/templates/opensuse-legacy.spec
+++ b/py2pack/templates/opensuse-legacy.spec
@@ -108,3 +108,4 @@ python setup.py test
 {%- endif %}
 
 %changelog
+

--- a/py2pack/templates/opensuse.dsc
+++ b/py2pack/templates/opensuse.dsc
@@ -12,3 +12,4 @@ Depends: {% for req in requires %}python-{{ req|lower|parenthesize_version }}{{ 
 {%- if extras_require %}
 Suggests: {% for reqlist in extras_require.values() %}{% for req in reqlist %}python-{{ req|lower|parenthesize_version }}{{ ', ' if not loop.last }}{%- endfor %}{{ ', ' if not loop.last }}{%- endfor %}
 {%- endif %}
+

--- a/py2pack/templates/opensuse.spec
+++ b/py2pack/templates/opensuse.spec
@@ -126,3 +126,4 @@ BuildArch:      noarch
 {%- endif %}
 
 %changelog
+

--- a/py2pack/templates/opensuse.spec
+++ b/py2pack/templates/opensuse.spec
@@ -52,19 +52,19 @@ BuildRequires:  %{python_module {{ req }}}
 {%- if source_url.endswith('.zip') %}
 BuildRequires:  unzip
 {%- endif %}
+BuildRequires:  fdupes
 {%- if install_requires and install_requires is not none %}
 {%- for req in install_requires|sort %}
-Requires:       %{python_module {{ req }}}
+Requires:       python-{{ req }}
 {%- endfor %}
 {%- endif %}
 {%- if extras_require and extras_require is not none %}
 {%- for reqlist in extras_require.values() %}
 {%- for req in reqlist %}
-Suggests:       %{python_module {{ req }}}
+Suggests:       python-{{ req }}
 {%- endfor %}
 {%- endfor %}
 {%- endif %}
-BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 {%- if not has_ext_modules %}
 BuildArch:      noarch
 {%- endif %}
@@ -78,11 +78,16 @@ BuildArch:      noarch
 %setup -q -n {{ name }}-%{version}
 
 %build
-{% if has_ext_modules %}export CFLAGS="%{optflags}"{% endif %}
-%python_build
+{% if has_ext_modules %}export CFLAGS="%{optflags}"
+{% endif %}%python_build
 
 %install
 %python_install
+{%- if has_ext_modules %}
+%python_expand %fdupes %{buildroot}%{$python_sitearch}
+{%- else %}
+%python_expand %fdupes %{buildroot}%{$python_sitelib}
+{%- endif %}
 
 {%- if testsuite or test_suite %}
 %if %{with test}

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,6 +19,7 @@ classifier =
     Programming Language :: Python :: 3.3
     Programming Language :: Python :: 3.4
     Programming Language :: Python :: 3.5
+    Programming Language :: Python :: 3.6
     Topic :: Software Development :: Code Generators
     Topic :: Software Development :: Pre-processors
 

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ try:
 except ImportError:
     pass
 
-setuptools.setup(
-    setup_requires=['pbr>=1.8'],
-    pbr=True)
+setuptools.setup(setup_requires=['pbr>=1.8'],
+                 pbr=True,
+                 test_suite='test',
+                 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py35,pep8,cover
+envlist = py27,py35,py36,pep8,cover
 
 [testenv]
 usedevelop = True


### PR DESCRIPTION
* unify trailing whitespaces in templates
  tough there is one too much, the resulting file only has one, which is correct
* Fix opensuse's multipython template, see openSUSE/py2pack#82
* Also support for python 3.6 	
* Enable tests with python setup.py test
  and make setup.py flake8-compatible