### PR TITLE
Compare generated specfiles with saved output

### DIFF
--- a/py2pack/templates/opensuse-legacy.spec
+++ b/py2pack/templates/opensuse-legacy.spec
@@ -108,3 +108,4 @@ python setup.py test
 {%- endif %}
 
 %changelog
+

--- a/py2pack/templates/opensuse.dsc
+++ b/py2pack/templates/opensuse.dsc
@@ -12,3 +12,4 @@ Depends: {% for req in requires %}python-{{ req|lower|parenthesize_version }}{{ 
 {%- if extras_require %}
 Suggests: {% for reqlist in extras_require.values() %}{% for req in reqlist %}python-{{ req|lower|parenthesize_version }}{{ ', ' if not loop.last }}{%- endfor %}{{ ', ' if not loop.last }}{%- endfor %}
 {%- endif %}
+

--- a/py2pack/templates/opensuse.spec
+++ b/py2pack/templates/opensuse.spec
@@ -126,3 +126,4 @@ BuildArch:      noarch
 {%- endif %}
 
 %changelog
+

--- a/py2pack/templates/opensuse.spec
+++ b/py2pack/templates/opensuse.spec
@@ -52,19 +52,19 @@ BuildRequires:  %{python_module {{ req }}}
 {%- if source_url.endswith('.zip') %}
 BuildRequires:  unzip
 {%- endif %}
+BuildRequires:  fdupes
 {%- if install_requires and install_requires is not none %}
 {%- for req in install_requires|sort %}
-Requires:       %{python_module {{ req }}}
+Requires:       python-{{ req }}
 {%- endfor %}
 {%- endif %}
 {%- if extras_require and extras_require is not none %}
 {%- for reqlist in extras_require.values() %}
 {%- for req in reqlist %}
-Suggests:       %{python_module {{ req }}}
+Suggests:       python-{{ req }}
 {%- endfor %}
 {%- endfor %}
 {%- endif %}
-BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 {%- if not has_ext_modules %}
 BuildArch:      noarch
 {%- endif %}
@@ -78,11 +78,16 @@ BuildArch:      noarch
 %setup -q -n {{ name }}-%{version}
 
 %build
-{% if has_ext_modules %}export CFLAGS="%{optflags}"{% endif %}
-%python_build
+{% if has_ext_modules %}export CFLAGS="%{optflags}"
+{% endif %}%python_build
 
 %install
 %python_install
+{%- if has_ext_modules %}
+%python_expand %fdupes %{buildroot}%{$python_sitearch}
+{%- else %}
+%python_expand %fdupes %{buildroot}%{$python_sitelib}
+{%- endif %}
 
 {%- if testsuite or test_suite %}
 %if %{with test}

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,6 +19,7 @@ classifier =
     Programming Language :: Python :: 3.3
     Programming Language :: Python :: 3.4
     Programming Language :: Python :: 3.5
+    Programming Language :: Python :: 3.6
     Topic :: Software Development :: Code Generators
     Topic :: Software Development :: Pre-processors
 

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ try:
 except ImportError:
     pass
 
-setuptools.setup(
-    setup_requires=['pbr>=1.8'],
-    pbr=True)
+setuptools.setup(setup_requires=['pbr>=1.8'],
+                 pbr=True,
+                 test_suite='test',
+                 )

--- a/test/examples/py2pack-fedora.spec
+++ b/test/examples/py2pack-fedora.spec
@@ -1,0 +1,170 @@
+#
+# spec file for package python-py2pack
+#
+# Copyright (c) 2017 __USER__.
+#
+
+Name:           python-py2pack
+Version:        0.8.0
+Release:        0
+Url:            http://github.com/openSUSE/py2pack
+Summary:        Generate distribution packages from PyPI
+License:        Apache-2.0
+Group:          Development/Languages/Python
+Source:         https://files.pythonhosted.org/packages/source/p/py2pack/py2pack-%{version}.tar.gz
+BuildRoot:      %{_tmppath}/%{name}-%{version}-build
+BuildRequires:  python-devel
+
+%description
+Py2pack: Generate distribution packages from PyPI
+=================================================
+
+.. image:: https://travis-ci.org/openSUSE/py2pack.png?branch=master
+        :target: https://travis-ci.org/openSUSE/py2pack
+
+
+This script allows to generate RPM spec or DEB dsc files from Python modules.
+It allows to list Python modules or search for them on the Python Package Index
+(PyPI). Conveniently, it can fetch tarballs and changelogs making it an
+universal tool to package Python modules.
+
+
+Installation
+------------
+
+To install py2pack from the `Python Package Index`_, simply:
+
+.. code-block:: bash
+
+    $ pip install py2pack
+
+Or, if you absolutely must:
+
+.. code-block:: bash
+
+    $ easy_install py2pack
+
+But, you really shouldn't do that. Lastly, you can check your distro of choice
+if they provide packages. For openSUSE, you can find packages in the `Open
+Build Service`_ for all releases. If you happen to use openSUSE:Factory (the
+rolling release / development version), simply:
+
+.. code-block:: bash
+
+    $ sudo zypper install python-py2pack
+
+
+Usage
+-----
+
+Lets suppose you want to package zope.interface_ and you don't know how it is named
+exactly. First of all, you can search for it and download the source tarball if
+you found the correct module:
+
+.. code-block:: bash
+
+    $ py2pack search zope.interface
+    searching for module zope.interface...
+    found zope.interface-3.6.1
+    $ py2pack fetch zope.interface
+    downloading package zope.interface-3.6.1...
+    from http://pypi.python.org/packages/source/z/zope.interface/zope.interface-3.6.1.tar.gz
+
+
+As a next step you may want to generate a package recipe for your distribution.
+For RPM_-based distributions (let's use openSUSE_ as an example), you want to
+generate a spec file (named 'python-zope.interface.spec'):
+
+.. code-block:: bash
+
+    $ py2pack generate zope.interface -t opensuse.spec -f python-zope.interface.spec
+
+The source tarball and the package recipe is all you need to generate the RPM_
+(or DEB_) file.
+This final step may depend on which distribution you use. Again,
+for openSUSE_ (and by using the `Open Build Service`_), the complete recipe is:
+
+.. code-block:: bash
+
+    $ osc mkpac python-zope.interface
+    $ cd python-zope.interface
+    $ py2pack fetch zope.interface
+    $ py2pack generate zope.interface -f python-zope.interface.spec
+    $ osc build
+    ...
+
+Depending on the module, you may have to adapt the resulting spec file slightly.
+To get further help about py2pack usage, issue the following command:
+
+.. code-block:: bash
+
+    $ py2pack help
+
+
+Hacking and contributing
+------------------------
+
+You can test py2pack from your git checkout by executing the py2pack module:
+
+.. code-block:: bash
+
+    $ python -m py2pack
+
+Fork `the repository`_ on Github to start making your changes to the **master**
+branch (or branch off of it). Don't forget to write a test for fixed issues or
+implemented features whenever appropriate. You can invoke the testsuite from
+the repository root directory via `tox`_:
+
+.. code-block:: bash
+
+    $ tox
+
+To run a single test class via `tox`_, use i.e.:
+
+.. code-block:: bash
+
+    $ tox -epy27 test.test_py2pack:Py2packTestCase
+
+
+You can also run `nose`_ directly:
+
+.. code-block:: bash
+
+    $ nosetests
+
+It assumes you have the test dependencies installed (available on PYTHONPATH)
+on your system.
+
+:copyright: (c) 2013 Sascha Peilicke.
+:license: Apache-2.0, see LICENSE for more details.
+
+
+.. _argparse: http://pypi.python.org/pypi/argparse
+.. _Jinja2: http://pypi.python.org/pypi/Jinja2
+.. _zope.interface: http://pypi.python.org/pypi/zope.interface/
+.. _openSUSE: http://www.opensuse.org/en/
+.. _RPM: http://en.wikipedia.org/wiki/RPM_Package_Manager
+.. _DEB: http://en.wikipedia.org/wiki/Deb_(file_format)
+.. _`Python Package Index`: https://pypi.python.org/pypi/rapport
+.. _`Open Build Service`: https://build.opensuse.org/package/show?package=rapport&project=devel:languages:python
+.. _`the repository`: https://github.com/openSUSE/py2pack
+.. _`nose`: https://nose.readthedocs.org
+.. _`tox`: http://testrun.org/tox
+
+%prep
+%setup -q -n py2pack-%{version}
+
+%build
+python setup.py build
+
+%install
+python setup.py install --prefix=%{_prefix} --root=%{buildroot}
+
+%clean
+rm -rf %{buildroot}
+
+%files
+%defattr(-,root,root,-)
+%{python_sitelib}/*
+
+%changelog

--- a/test/examples/py2pack-mageia.spec
+++ b/test/examples/py2pack-mageia.spec
@@ -1,0 +1,32 @@
+%define mod_name py2pack
+
+Name:           python-%{mod_name}
+Version:        0.8.0
+Release:        %mkrel 1
+Url:            http://github.com/openSUSE/py2pack
+Summary:        Generate distribution packages from PyPI
+License:        Apache-2.0
+Group:          Development/Python
+Source:         https://files.pythonhosted.org/packages/source/p/py2pack/py2pack-%{version}.tar.gz
+BuildRoot:      %{_tmppath}/%{name}-%{version}-buildroot
+BuildRequires:  python-devel
+
+%description
+Generate distribution packages from PyPI
+
+
+%prep
+%setup -q -n %{mod_name}-%{version}
+
+%build
+%{__python} setup.py build
+
+%install
+%{__python} setup.py install --prefix=%{_prefix} --root=%{buildroot}
+
+%clean
+rm -rf %{buildroot}
+
+%files -f
+%defattr(-,root,root)
+%{python_sitelib}/*

--- a/test/examples/py2pack-opensuse-legacy.spec
+++ b/test/examples/py2pack-opensuse-legacy.spec
@@ -1,0 +1,180 @@
+#
+# spec file for package python-py2pack
+#
+# Copyright (c) 2017 SUSE LINUX GmbH, Nuernberg, Germany.
+#
+# All modifications and additions to the file contributed by third parties
+# remain the property of their copyright owners, unless otherwise agreed
+# upon. The license for this file, and modifications and additions to the
+# file, is the same license as for the pristine package itself (unless the
+# license for the pristine package is not an Open Source License, in which
+# case the license is the MIT License). An "Open Source License" is a
+# license that conforms to the Open Source Definition (Version 1.9)
+# published by the Open Source Initiative.
+
+# Please submit bugfixes or comments via http://bugs.opensuse.org/
+
+
+Name:           python-py2pack
+Version:        0.8.0
+Release:        0
+License:        Apache-2.0
+Summary:        Generate distribution packages from PyPI
+Url:            http://github.com/openSUSE/py2pack
+Group:          Development/Languages/Python
+Source:         https://files.pythonhosted.org/packages/source/p/py2pack/py2pack-%{version}.tar.gz
+BuildRequires:  python-devel
+BuildRequires:  python-setuptools
+BuildRoot:      %{_tmppath}/%{name}-%{version}-build
+BuildArch:      noarch
+
+%description
+Py2pack: Generate distribution packages from PyPI
+=================================================
+
+.. image:: https://travis-ci.org/openSUSE/py2pack.png?branch=master
+        :target: https://travis-ci.org/openSUSE/py2pack
+
+
+This script allows to generate RPM spec or DEB dsc files from Python modules.
+It allows to list Python modules or search for them on the Python Package Index
+(PyPI). Conveniently, it can fetch tarballs and changelogs making it an
+universal tool to package Python modules.
+
+
+Installation
+------------
+
+To install py2pack from the `Python Package Index`_, simply:
+
+.. code-block:: bash
+
+    $ pip install py2pack
+
+Or, if you absolutely must:
+
+.. code-block:: bash
+
+    $ easy_install py2pack
+
+But, you really shouldn't do that. Lastly, you can check your distro of choice
+if they provide packages. For openSUSE, you can find packages in the `Open
+Build Service`_ for all releases. If you happen to use openSUSE:Factory (the
+rolling release / development version), simply:
+
+.. code-block:: bash
+
+    $ sudo zypper install python-py2pack
+
+
+Usage
+-----
+
+Lets suppose you want to package zope.interface_ and you don't know how it is named
+exactly. First of all, you can search for it and download the source tarball if
+you found the correct module:
+
+.. code-block:: bash
+
+    $ py2pack search zope.interface
+    searching for module zope.interface...
+    found zope.interface-3.6.1
+    $ py2pack fetch zope.interface
+    downloading package zope.interface-3.6.1...
+    from http://pypi.python.org/packages/source/z/zope.interface/zope.interface-3.6.1.tar.gz
+
+
+As a next step you may want to generate a package recipe for your distribution.
+For RPM_-based distributions (let's use openSUSE_ as an example), you want to
+generate a spec file (named 'python-zope.interface.spec'):
+
+.. code-block:: bash
+
+    $ py2pack generate zope.interface -t opensuse.spec -f python-zope.interface.spec
+
+The source tarball and the package recipe is all you need to generate the RPM_
+(or DEB_) file.
+This final step may depend on which distribution you use. Again,
+for openSUSE_ (and by using the `Open Build Service`_), the complete recipe is:
+
+.. code-block:: bash
+
+    $ osc mkpac python-zope.interface
+    $ cd python-zope.interface
+    $ py2pack fetch zope.interface
+    $ py2pack generate zope.interface -f python-zope.interface.spec
+    $ osc build
+    ...
+
+Depending on the module, you may have to adapt the resulting spec file slightly.
+To get further help about py2pack usage, issue the following command:
+
+.. code-block:: bash
+
+    $ py2pack help
+
+
+Hacking and contributing
+------------------------
+
+You can test py2pack from your git checkout by executing the py2pack module:
+
+.. code-block:: bash
+
+    $ python -m py2pack
+
+Fork `the repository`_ on Github to start making your changes to the **master**
+branch (or branch off of it). Don't forget to write a test for fixed issues or
+implemented features whenever appropriate. You can invoke the testsuite from
+the repository root directory via `tox`_:
+
+.. code-block:: bash
+
+    $ tox
+
+To run a single test class via `tox`_, use i.e.:
+
+.. code-block:: bash
+
+    $ tox -epy27 test.test_py2pack:Py2packTestCase
+
+
+You can also run `nose`_ directly:
+
+.. code-block:: bash
+
+    $ nosetests
+
+It assumes you have the test dependencies installed (available on PYTHONPATH)
+on your system.
+
+:copyright: (c) 2013 Sascha Peilicke.
+:license: Apache-2.0, see LICENSE for more details.
+
+
+.. _argparse: http://pypi.python.org/pypi/argparse
+.. _Jinja2: http://pypi.python.org/pypi/Jinja2
+.. _zope.interface: http://pypi.python.org/pypi/zope.interface/
+.. _openSUSE: http://www.opensuse.org/en/
+.. _RPM: http://en.wikipedia.org/wiki/RPM_Package_Manager
+.. _DEB: http://en.wikipedia.org/wiki/Deb_(file_format)
+.. _`Python Package Index`: https://pypi.python.org/pypi/rapport
+.. _`Open Build Service`: https://build.opensuse.org/package/show?package=rapport&project=devel:languages:python
+.. _`the repository`: https://github.com/openSUSE/py2pack
+.. _`nose`: https://nose.readthedocs.org
+.. _`tox`: http://testrun.org/tox
+
+%prep
+%setup -q -n py2pack-%{version}
+
+%build
+python setup.py build
+
+%install
+python setup.py install --prefix=%{_prefix} --root=%{buildroot}
+
+%files
+%defattr(-,root,root,-)
+%{python_sitelib}/*
+
+%changelog

--- a/test/examples/py2pack-opensuse.dsc
+++ b/test/examples/py2pack-opensuse.dsc
@@ -1,0 +1,8 @@
+Format: 1.0
+Source: py2pack
+Version: 0.8.0
+Binary: python-py2pack
+Maintainer: __USER__
+Architecture: any
+Standards-Version: 3.7.1
+Build-Depends: debhelper (>= 4.0.0), python-dev

--- a/test/examples/py2pack-opensuse.spec
+++ b/test/examples/py2pack-opensuse.spec
@@ -1,0 +1,186 @@
+#
+# spec file for package python-py2pack
+#
+# Copyright (c) 2017 SUSE LINUX GmbH, Nuernberg, Germany.
+#
+# All modifications and additions to the file contributed by third parties
+# remain the property of their copyright owners, unless otherwise agreed
+# upon. The license for this file, and modifications and additions to the
+# file, is the same license as for the pristine package itself (unless the
+# license for the pristine package is not an Open Source License, in which
+# case the license is the MIT License). An "Open Source License" is a
+# license that conforms to the Open Source Definition (Version 1.9)
+# published by the Open Source Initiative.
+
+# Please submit bugfixes or comments via http://bugs.opensuse.org/
+
+
+%{?!python_module:%define python_module() python-%{**} python3-%{**}}
+%bcond_without test
+Name:           python-py2pack
+Version:        0.8.0
+Release:        0
+License:        Apache-2.0
+Summary:        Generate distribution packages from PyPI
+Url:            http://github.com/openSUSE/py2pack
+Group:          Development/Languages/Python
+Source:         https://files.pythonhosted.org/packages/source/p/py2pack/py2pack-%{version}.tar.gz
+BuildRequires:  python-rpm-macros
+BuildRequires:  %{python_module devel}
+BuildRequires:  %{python_module setuptools}
+BuildRequires:  fdupes
+BuildArch:      noarch
+
+%python_subpackages
+
+%description
+Py2pack: Generate distribution packages from PyPI
+=================================================
+
+.. image:: https://travis-ci.org/openSUSE/py2pack.png?branch=master
+        :target: https://travis-ci.org/openSUSE/py2pack
+
+
+This script allows to generate RPM spec or DEB dsc files from Python modules.
+It allows to list Python modules or search for them on the Python Package Index
+(PyPI). Conveniently, it can fetch tarballs and changelogs making it an
+universal tool to package Python modules.
+
+
+Installation
+------------
+
+To install py2pack from the `Python Package Index`_, simply:
+
+.. code-block:: bash
+
+    $ pip install py2pack
+
+Or, if you absolutely must:
+
+.. code-block:: bash
+
+    $ easy_install py2pack
+
+But, you really shouldn't do that. Lastly, you can check your distro of choice
+if they provide packages. For openSUSE, you can find packages in the `Open
+Build Service`_ for all releases. If you happen to use openSUSE:Factory (the
+rolling release / development version), simply:
+
+.. code-block:: bash
+
+    $ sudo zypper install python-py2pack
+
+
+Usage
+-----
+
+Lets suppose you want to package zope.interface_ and you don't know how it is named
+exactly. First of all, you can search for it and download the source tarball if
+you found the correct module:
+
+.. code-block:: bash
+
+    $ py2pack search zope.interface
+    searching for module zope.interface...
+    found zope.interface-3.6.1
+    $ py2pack fetch zope.interface
+    downloading package zope.interface-3.6.1...
+    from http://pypi.python.org/packages/source/z/zope.interface/zope.interface-3.6.1.tar.gz
+
+
+As a next step you may want to generate a package recipe for your distribution.
+For RPM_-based distributions (let's use openSUSE_ as an example), you want to
+generate a spec file (named 'python-zope.interface.spec'):
+
+.. code-block:: bash
+
+    $ py2pack generate zope.interface -t opensuse.spec -f python-zope.interface.spec
+
+The source tarball and the package recipe is all you need to generate the RPM_
+(or DEB_) file.
+This final step may depend on which distribution you use. Again,
+for openSUSE_ (and by using the `Open Build Service`_), the complete recipe is:
+
+.. code-block:: bash
+
+    $ osc mkpac python-zope.interface
+    $ cd python-zope.interface
+    $ py2pack fetch zope.interface
+    $ py2pack generate zope.interface -f python-zope.interface.spec
+    $ osc build
+    ...
+
+Depending on the module, you may have to adapt the resulting spec file slightly.
+To get further help about py2pack usage, issue the following command:
+
+.. code-block:: bash
+
+    $ py2pack help
+
+
+Hacking and contributing
+------------------------
+
+You can test py2pack from your git checkout by executing the py2pack module:
+
+.. code-block:: bash
+
+    $ python -m py2pack
+
+Fork `the repository`_ on Github to start making your changes to the **master**
+branch (or branch off of it). Don't forget to write a test for fixed issues or
+implemented features whenever appropriate. You can invoke the testsuite from
+the repository root directory via `tox`_:
+
+.. code-block:: bash
+
+    $ tox
+
+To run a single test class via `tox`_, use i.e.:
+
+.. code-block:: bash
+
+    $ tox -epy27 test.test_py2pack:Py2packTestCase
+
+
+You can also run `nose`_ directly:
+
+.. code-block:: bash
+
+    $ nosetests
+
+It assumes you have the test dependencies installed (available on PYTHONPATH)
+on your system.
+
+:copyright: (c) 2013 Sascha Peilicke.
+:license: Apache-2.0, see LICENSE for more details.
+
+
+.. _argparse: http://pypi.python.org/pypi/argparse
+.. _Jinja2: http://pypi.python.org/pypi/Jinja2
+.. _zope.interface: http://pypi.python.org/pypi/zope.interface/
+.. _openSUSE: http://www.opensuse.org/en/
+.. _RPM: http://en.wikipedia.org/wiki/RPM_Package_Manager
+.. _DEB: http://en.wikipedia.org/wiki/Deb_(file_format)
+.. _`Python Package Index`: https://pypi.python.org/pypi/rapport
+.. _`Open Build Service`: https://build.opensuse.org/package/show?package=rapport&project=devel:languages:python
+.. _`the repository`: https://github.com/openSUSE/py2pack
+.. _`nose`: https://nose.readthedocs.org
+.. _`tox`: http://testrun.org/tox
+
+%prep
+%setup -q -n py2pack-%{version}
+
+%build
+%python_build
+
+%install
+%python_install
+%python_expand %fdupes %{buildroot}%{$python_sitelib}
+
+%files %{python_files}
+%defattr(-,root,root,-)
+%{python_sitelib}/*
+
+%changelog

--- a/test/examples/py2pack-opensuse.spec~
+++ b/test/examples/py2pack-opensuse.spec~
@@ -1,0 +1,184 @@
+#
+# spec file for package python-py2pack
+#
+# Copyright (c) 2017 SUSE LINUX GmbH, Nuernberg, Germany.
+#
+# All modifications and additions to the file contributed by third parties
+# remain the property of their copyright owners, unless otherwise agreed
+# upon. The license for this file, and modifications and additions to the
+# file, is the same license as for the pristine package itself (unless the
+# license for the pristine package is not an Open Source License, in which
+# case the license is the MIT License). An "Open Source License" is a
+# license that conforms to the Open Source Definition (Version 1.9)
+# published by the Open Source Initiative.
+
+# Please submit bugfixes or comments via http://bugs.opensuse.org/
+
+
+%{?!python_module:%define python_module() python-%{**} python3-%{**}}
+%bcond_without test
+Name:           python-py2pack
+Version:        0.8.0
+Release:        0
+License:        Apache-2.0
+Summary:        Generate distribution packages from PyPI
+Url:            http://github.com/openSUSE/py2pack
+Group:          Development/Languages/Python
+Source:         https://files.pythonhosted.org/packages/source/p/py2pack/py2pack-%{version}.tar.gz
+BuildRequires:  python-rpm-macros
+BuildRequires:  %{python_module devel}
+BuildRequires:  %{python_module setuptools}
+BuildArch:      noarch
+
+%python_subpackages
+
+%description
+Py2pack: Generate distribution packages from PyPI
+=================================================
+
+.. image:: https://travis-ci.org/openSUSE/py2pack.png?branch=master
+        :target: https://travis-ci.org/openSUSE/py2pack
+
+
+This script allows to generate RPM spec or DEB dsc files from Python modules.
+It allows to list Python modules or search for them on the Python Package Index
+(PyPI). Conveniently, it can fetch tarballs and changelogs making it an
+universal tool to package Python modules.
+
+
+Installation
+------------
+
+To install py2pack from the `Python Package Index`_, simply:
+
+.. code-block:: bash
+
+    $ pip install py2pack
+
+Or, if you absolutely must:
+
+.. code-block:: bash
+
+    $ easy_install py2pack
+
+But, you really shouldn't do that. Lastly, you can check your distro of choice
+if they provide packages. For openSUSE, you can find packages in the `Open
+Build Service`_ for all releases. If you happen to use openSUSE:Factory (the
+rolling release / development version), simply:
+
+.. code-block:: bash
+
+    $ sudo zypper install python-py2pack
+
+
+Usage
+-----
+
+Lets suppose you want to package zope.interface_ and you don't know how it is named
+exactly. First of all, you can search for it and download the source tarball if
+you found the correct module:
+
+.. code-block:: bash
+
+    $ py2pack search zope.interface
+    searching for module zope.interface...
+    found zope.interface-3.6.1
+    $ py2pack fetch zope.interface
+    downloading package zope.interface-3.6.1...
+    from http://pypi.python.org/packages/source/z/zope.interface/zope.interface-3.6.1.tar.gz
+
+
+As a next step you may want to generate a package recipe for your distribution.
+For RPM_-based distributions (let's use openSUSE_ as an example), you want to
+generate a spec file (named 'python-zope.interface.spec'):
+
+.. code-block:: bash
+
+    $ py2pack generate zope.interface -t opensuse.spec -f python-zope.interface.spec
+
+The source tarball and the package recipe is all you need to generate the RPM_
+(or DEB_) file.
+This final step may depend on which distribution you use. Again,
+for openSUSE_ (and by using the `Open Build Service`_), the complete recipe is:
+
+.. code-block:: bash
+
+    $ osc mkpac python-zope.interface
+    $ cd python-zope.interface
+    $ py2pack fetch zope.interface
+    $ py2pack generate zope.interface -f python-zope.interface.spec
+    $ osc build
+    ...
+
+Depending on the module, you may have to adapt the resulting spec file slightly.
+To get further help about py2pack usage, issue the following command:
+
+.. code-block:: bash
+
+    $ py2pack help
+
+
+Hacking and contributing
+------------------------
+
+You can test py2pack from your git checkout by executing the py2pack module:
+
+.. code-block:: bash
+
+    $ python -m py2pack
+
+Fork `the repository`_ on Github to start making your changes to the **master**
+branch (or branch off of it). Don't forget to write a test for fixed issues or
+implemented features whenever appropriate. You can invoke the testsuite from
+the repository root directory via `tox`_:
+
+.. code-block:: bash
+
+    $ tox
+
+To run a single test class via `tox`_, use i.e.:
+
+.. code-block:: bash
+
+    $ tox -epy27 test.test_py2pack:Py2packTestCase
+
+
+You can also run `nose`_ directly:
+
+.. code-block:: bash
+
+    $ nosetests
+
+It assumes you have the test dependencies installed (available on PYTHONPATH)
+on your system.
+
+:copyright: (c) 2013 Sascha Peilicke.
+:license: Apache-2.0, see LICENSE for more details.
+
+
+.. _argparse: http://pypi.python.org/pypi/argparse
+.. _Jinja2: http://pypi.python.org/pypi/Jinja2
+.. _zope.interface: http://pypi.python.org/pypi/zope.interface/
+.. _openSUSE: http://www.opensuse.org/en/
+.. _RPM: http://en.wikipedia.org/wiki/RPM_Package_Manager
+.. _DEB: http://en.wikipedia.org/wiki/Deb_(file_format)
+.. _`Python Package Index`: https://pypi.python.org/pypi/rapport
+.. _`Open Build Service`: https://build.opensuse.org/package/show?package=rapport&project=devel:languages:python
+.. _`the repository`: https://github.com/openSUSE/py2pack
+.. _`nose`: https://nose.readthedocs.org
+.. _`tox`: http://testrun.org/tox
+
+%prep
+%setup -q -n py2pack-%{version}
+
+%build
+%python_build
+
+%install
+%python_install
+
+%files %{python_files}
+%defattr(-,root,root,-)
+%{python_sitelib}/*
+
+%changelog

--- a/test/test_template.py
+++ b/test/test_template.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2017, Sebastian Wagner <sebix@sebix.at>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import os.path
+import pwd
+import tempfile
+import unittest
+
+import py2pack
+
+
+class Args(object):
+    run = False
+    template = ''
+    filename = ''
+    name = 'py2pack'
+    version = None
+
+
+def generate_template_function(template):
+    def test_template(self):
+        """ Test if generated specfile for %s equals to stored one. """ % template
+        args = Args()
+        args.template = template
+        with tempfile.NamedTemporaryFile(mode='w+t') as filehandle:
+            filename = filehandle.name
+            args.filename = filename
+            py2pack.generate(args)
+            filehandle.seek(0)
+            written_spec = filehandle.read()
+        with open(os.path.join(self.compare_dir, 'py2pack-%s' % template)) as filehandle:
+            required = filehandle.read()
+        required = required.replace('__USER__', self.username, 1)
+        self.assertEqual(written_spec, required)
+    return test_template
+
+
+class TemplateTestCase(unittest.TestCase):
+    compare_dir = os.path.join(os.path.dirname(__file__), 'examples')
+    maxDiff = None
+    username = pwd.getpwuid(os.getuid())[4]
+
+
+for template in ('fedora.spec', 'mageia.spec', 'opensuse-legacy.spec', 'opensuse.dsc', 'opensuse.spec'):
+    setattr(TemplateTestCase,
+            'test_template_%s' % template,
+            generate_template_function(template))

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py35,pep8,cover
+envlist = py27,py35,py36,pep8,cover
 
 [testenv]
 usedevelop = True


### PR DESCRIPTION
Based on previous PR #86 

Requires internet access

Easily detects whitespaces issues as those raised in openSUSE/py2pack#82 but it's a bit more effort to change them.