### PR TITLE
opensuse template updates and pep8 fixes

### DIFF
--- a/py2pack/__init__.py
+++ b/py2pack/__init__.py
@@ -177,15 +177,15 @@ def _license_from_classifiers(data):
 
 def _normalize_license(data):
     """try to get SDPX license"""
-    l = data.get('license', None)
-    if not l:
+    license = data.get('license', None)
+    if not license:
         # try to get license from classifiers
-        l = _license_from_classifiers(data)
-    if l:
-        if l in SDPX_LICENSES.keys():
-            data['license'] = SDPX_LICENSES[l]
+        license = _license_from_classifiers(data)
+    if license:
+        if license in SDPX_LICENSES.keys():
+            data['license'] = SDPX_LICENSES[license]
         else:
-            data['license'] = "%s (FIXME:No SPDX)" % (l)
+            data['license'] = "%s (FIXME:No SPDX)" % (license)
     else:
         data['license'] = ""
 

--- a/py2pack/proxy.py
+++ b/py2pack/proxy.py
@@ -17,11 +17,11 @@
 
 try:
     import http.client as httplib
-except:
+except ImportError:
     import httplib
 try:
     import xmlrpc.client as xmlrpclib
-except:
+except ImportError:
     import xmlrpclib
 
 

--- a/py2pack/setup.py
+++ b/py2pack/setup.py
@@ -31,7 +31,7 @@ class DocCommand(Command):
         try:
             subprocess.call(["xsltproc", "--output", "doc/py2pack.html", "/usr/share/xml/docbook/stylesheet/nwalsh/current/html/docbook.xsl", "doc/src/py2pack.xml.in"])
             subprocess.call(["xsltproc", "--output", "doc/py2pack.1", "/usr/share/xml/docbook/stylesheet/nwalsh/current/manpages/docbook.xsl", "doc/src/py2pack.xml.in"])
-        except:
+        except OSError:
             pass
 
 

--- a/py2pack/templates/opensuse.spec
+++ b/py2pack/templates/opensuse.spec
@@ -16,7 +16,6 @@
 
 
 %{?!python_module:%define python_module() python-%{**} python3-%{**}}
-%bcond_without test
 Name:           python-{{ name }}
 Version:        {{ version }}
 Release:        0
@@ -33,20 +32,18 @@ BuildRequires:  %{python_module setuptools}
 BuildRequires:  %{python_module {{ req }}}
 {%- endfor %}
 {%- endif %}
+{%- if (install_requires and install_requires is not none) or (tests_require and tests_require is not none) %}
+# SECTION test requirements
 {%- if install_requires and install_requires is not none %}
-%if %{with test}
 {%- for req in install_requires|sort %}
 BuildRequires:  %{python_module {{ req }}}
 {%- endfor %}
-%endif
 {%- endif %}
 {%- if tests_require and tests_require is not none %}
-# SECTION test requirements
-%if %{with test}
 {%- for req in tests_require|sort %}
 BuildRequires:  %{python_module {{ req }}}
 {%- endfor %}
-%endif
+{%- endif %}
 # /SECTION
 {%- endif %}
 {%- if source_url.endswith('.zip') %}
@@ -90,14 +87,11 @@ BuildArch:      noarch
 {%- endif %}
 
 {%- if testsuite or test_suite %}
-%if %{with test}
 %check
 %python_exec setup.py test
-%endif
 {%- endif %}
 
 %files %{python_files}
-%defattr(-,root,root,-)
 {%- if doc_files and doc_files is not none %}
 %doc {{ doc_files|join(" ") }}
 {%- endif %}

--- a/py2pack/version.py
+++ b/py2pack/version.py
@@ -17,7 +17,7 @@
 
 try:
     from pbr import version as pbr_version
-except:
+except ImportError:
     # no pbr available
     version = 'unknown'
     pass

--- a/test/examples/py2pack-opensuse.spec
+++ b/test/examples/py2pack-opensuse.spec
@@ -16,7 +16,6 @@
 
 
 %{?!python_module:%define python_module() python-%{**} python3-%{**}}
-%bcond_without test
 Name:           python-py2pack
 Version:        0.8.0
 Release:        0
@@ -180,7 +179,6 @@ on your system.
 %python_expand %fdupes %{buildroot}%{$python_sitelib}
 
 %files %{python_files}
-%defattr(-,root,root,-)
 %{python_sitelib}/*
 
 %changelog


### PR DESCRIPTION
* remove test conditions, requests containing them won't be accepted anymore (see e.g. https://build.opensuse.org/request/show/557831 and lots of others)
* combine test requirements lists
* remove obsolete %defattr(-,root,root,-), spec-cleaner removes it anyway