### PR TITLE
Support %license macro

### DIFF
--- a/py2pack/templates/opensuse-legacy.spec
+++ b/py2pack/templates/opensuse-legacy.spec
@@ -78,6 +78,9 @@ python setup.py test
 {%- if doc_files and doc_files is not none %}
 %doc {{ doc_files|join(" ") }}
 {%- endif %}
+{%- if license_files and license_files is not none %}
+%license {{ license_files|join(" ") }}
+{%- endif %}
 {%- if scripts and scripts is not none %}
 {%- for script in scripts %}
 %{_bindir}/{{ script|basename }}

--- a/py2pack/templates/opensuse.spec
+++ b/py2pack/templates/opensuse.spec
@@ -95,6 +95,9 @@ BuildArch:      noarch
 {%- if doc_files and doc_files is not none %}
 %doc {{ doc_files|join(" ") }}
 {%- endif %}
+{%- if license_files and license_files is not none %}
+%license {{ license_files|join(" ") }}
+{%- endif %}
 {%- if scripts and scripts is not none %}
 {%- for script in scripts %}
 %python3_only %{_bindir}/{{ script|basename }}

--- a/test/test_py2pack.py
+++ b/test/test_py2pack.py
@@ -88,6 +88,10 @@ class Py2packTestCase(unittest.TestCase):
         d = {'classifiers': value}
         self.assertEqual(py2pack._license_from_classifiers(d), expected)
 
+    def test__quote_shell_metacharacters(self):
+        self.assertEqual(py2pack._quote_shell_metacharacters("abc"), "abc")
+        self.assertEqual(py2pack._quote_shell_metacharacters("abc&"), "'abc&'")
+
     def test__prepare_template_env(self):
         template_dir = os.path.join(os.path.dirname(
             os.path.abspath(__file__)), '..', 'py2pack', 'templates')

--- a/tox.ini
+++ b/tox.ini
@@ -22,6 +22,6 @@ commands = python setup.py build_sphinx
 commands = flake8
 
 [flake8]
-ignore = E501,E402
+ignore = E501,E402,W605,W504
 show-source = True
 exclude = .venv,.tox,build,dist,doc,*egg


### PR DESCRIPTION
When generating a .spec file for openSUSE, use the %license macro when
a LICENSE or COPYING file is found instead of the %doc macro.
This is a recent change in openSUSE. See
https://en.opensuse.org/openSUSE:Packaging_guidelines#Licensing