### PR TITLE
Fix DeprecationWarnings and document py2pack/requires.py

### DIFF
--- a/py2pack/__init__.py
+++ b/py2pack/__init__.py
@@ -142,15 +142,15 @@ def _canonicalize_setup_data(data):
 
 
 def _quote_shell_metacharacters(string):
-    shell_metachars_re = re.compile("[|&;()<>\s]")
+    shell_metachars_re = re.compile(r"[|&;()<>\s]")
     if re.search(shell_metachars_re, string):
         return "'" + string + "'"
     return string
 
 
 def _augment_data_from_tarball(args, filename, data):
-    docs_re = re.compile("{0}-{1}\/((?:AUTHOR|ChangeLog|CHANGES|NEWS|README).*)".format(args.name, args.version), re.IGNORECASE)
-    license_re = re.compile("{0}-{1}\/((?:COPYING|LICENSE).*)".format(args.name, args.version), re.IGNORECASE)
+    docs_re = re.compile(r"{0}-{1}\/((?:AUTHOR|ChangeLog|CHANGES|NEWS|README).*)".format(args.name, args.version), re.IGNORECASE)
+    license_re = re.compile(r"{0}-{1}\/((?:COPYING|LICENSE).*)".format(args.name, args.version), re.IGNORECASE)
 
     data_archive = meta_utils.from_archive(filename)
     data.update(data_archive['data'])
@@ -241,7 +241,7 @@ def generate(args):
         data['source_url'] = args.name + '-' + args.version + '.zip'
     data['year'] = datetime.datetime.now().year                             # set current year
     data['user_name'] = pwd.getpwuid(os.getuid())[4]                        # set system user (packager)
-    data['summary_no_ending_dot'] = re.sub('(.*)\.', '\g<1>', data.get('summary', ""))
+    data['summary_no_ending_dot'] = re.sub(r'(.*)\.', r'\g<1>', data.get('summary', ""))
 
     tarball_file = glob.glob("{0}-{1}.*".format(args.name, args.version))
     # also check tarball files with underscore. Some packages have a name with

--- a/py2pack/requires.py
+++ b/py2pack/requires.py
@@ -43,7 +43,10 @@ def _requirement_filter_by_marker(req):
     system platform are checked.
     """
     if hasattr(req, 'marker') and req.marker:
-        marker_env = {'python_version': '.'.join(map(str, sys.version_info[:2])), 'sys_platform': sys.platform}
+        marker_env = {
+            'python_version': '.'.join(map(str, sys.version_info[:2])),
+            'sys_platform': sys.platform
+        }
         if not req.marker.evaluate(environment=marker_env):
             return False
     return True

--- a/py2pack/requires.py
+++ b/py2pack/requires.py
@@ -34,22 +34,22 @@ def _requirement_filter_by_marker(req):
 
 
 def _requirement_find_lowest_possible(req):
-        """ find lowest required version"""
-        version_dep = None
-        version_comp = None
-        for dep in req.specs:
-            version = pkg_resources.parse_version(dep[1])
-            # we don't want to have a not supported version as minimal version
-            if dep[0] == '!=':
-                continue
-            # try to use the lowest version available
-            # i.e. for ">=0.8.4,>=0.9.7", select "0.8.4"
-            if (not version_dep or
-                    version < pkg_resources.parse_version(version_dep)):
-                version_dep = dep[1]
-                version_comp = dep[0]
-        return filter(lambda x: x is not None,
-                      [req.unsafe_name, version_comp, version_dep])
+    """ find lowest required version"""
+    version_dep = None
+    version_comp = None
+    for dep in req.specs:
+        version = pkg_resources.parse_version(dep[1])
+        # we don't want to have a not supported version as minimal version
+        if dep[0] == '!=':
+            continue
+        # try to use the lowest version available
+        # i.e. for ">=0.8.4,>=0.9.7", select "0.8.4"
+        if (not version_dep or
+                version < pkg_resources.parse_version(version_dep)):
+            version_dep = dep[1]
+            version_comp = dep[0]
+    return filter(lambda x: x is not None,
+                  [req.unsafe_name, version_comp, version_dep])
 
 
 def _requirements_sanitize(req_list):

--- a/py2pack/requires.py
+++ b/py2pack/requires.py
@@ -27,7 +27,7 @@ For further information concerning requirements (and markers), see `PEP 508
 
 from __future__ import absolute_import
 from __future__ import print_function
-from typing import List, Optional  # pylint: disable=unused-import
+from typing import List, Optional  # noqa: F401, pylint: disable=unused-import
 import sys
 
 import pkg_resources

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ Jinja2
 setuptools
 six
 metaextract
+typing;python_version<'3.5'

--- a/test/test_requires.py
+++ b/test/test_requires.py
@@ -45,7 +45,7 @@ class Py2packRequiresTestCase(unittest.TestCase):
         ("pywin32>=1.0;sys_platform=='win32'  # PSF", False),
         ("foobar", True),
         ("foobar;python_version=='2.7'", sys.version_info[:2] == (2, 7)),
-        ("foobar;python_version=='3.5'", sys.version_info[:2] == (3, 5)),
+        ("foobar;python_version=='3.6'", sys.version_info[:2] == (3, 6)),
     )
     @unpack
     def test__requirement_filter_by_marker(self, req, expected):


### PR DESCRIPTION
This PR mainly adds documentation to `py2pack/requires.py`, adds type hints and (imho) improves the readability of the functions, by no longer using filter.