### PR TITLE
Documentation & additional tests for utils.py

### DIFF
--- a/py2pack/utils.py
+++ b/py2pack/utils.py
@@ -31,8 +31,8 @@ def _get_archive_filelist(filename):
         with zipfile.ZipFile(filename) as zip_file:
             names = sorted(zip_file.namelist())
     else:
-        raise Exception("Can not get filenames from '%s'. "
-                        "Not a tar or zip file" % filename)
+        raise ValueError("Can not get filenames from '{!s}'. "
+                         "Not a tar or zip file".format(filename))
     if "./" in names:
         names.remove("./")
     return names

--- a/py2pack/utils.py
+++ b/py2pack/utils.py
@@ -15,18 +15,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import List  # noqa: F401, pylint: disable=unused-import
+
 import tarfile
 import zipfile
 
 
 def _get_archive_filelist(filename):
-    names = []
+    # type: (str) -> List[str]
+    names = []  # type: List[str]
     if tarfile.is_tarfile(filename):
-        with tarfile.open(filename) as f:
-            names = sorted(f.getnames())
+        with tarfile.open(filename) as tar_file:
+            names = sorted(tar_file.getnames())
     elif zipfile.is_zipfile(filename):
-        with zipfile.ZipFile(filename) as f:
-            names = sorted(f.namelist())
+        with zipfile.ZipFile(filename) as zip_file:
+            names = sorted(zip_file.namelist())
     else:
         raise Exception("Can not get filenames from '%s'. "
                         "Not a tar or zip file" % filename)

--- a/py2pack/utils.py
+++ b/py2pack/utils.py
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""Module containing utility functions that fit nowhere else."""
+
 from typing import List  # noqa: F401, pylint: disable=unused-import
 
 import tarfile
@@ -23,6 +25,19 @@ import zipfile
 
 def _get_archive_filelist(filename):
     # type: (str) -> List[str]
+    """Extract the list of files from a tar or zip archive.
+
+    Args:
+        filename: name of the archive
+
+    Returns:
+        Sorted list of files in the archive, excluding './'
+
+    Raises:
+        ValueError: when the file is neither a zip nor a tar archive
+        FileNotFoundError: when the provided file does not exist (for Python 3)
+        IOError: when the provided file does not exist (for Python 2)
+    """
     names = []  # type: List[str]
     if tarfile.is_tarfile(filename):
         with tarfile.open(filename) as tar_file:

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -76,3 +76,20 @@ class Py2packUtilsTestCase(unittest.TestCase):
 
         self.assertIn(file_name, str(val_err.exception))
         self.assertIn("Not a tar or zip file", str(val_err.exception))
+
+    def test__get_archive_filelist_nonexistent_file(self):
+        file_name = os.path.join(
+            self.tmpdir, "this_does_not_exist.asdfqweruiae")
+
+        # tarfile.is_tarfile() throws an IOError in Python2.7 and
+        # FileNotFoundError  in Python3.6
+        try:
+            FileNotFoundError
+        except NameError:
+            FileNotFoundError = IOError
+
+        with self.assertRaises(FileNotFoundError) as f_not_found_err:
+            py2pack.utils._get_archive_filelist(file_name)
+
+        self.assertNotIn(
+            "Not a tar or zip file", str(f_not_found_err.exception))

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -64,3 +64,15 @@ class Py2packUtilsTestCase(unittest.TestCase):
         expected_files = sorted(["file1", "file2", "file3"])
         files = py2pack.utils._get_archive_filelist(file_name)
         self.assertEqual(expected_files, files)
+
+    def test__get_archive_filelist_invalid_archive(self):
+        file_name = os.path.join(self.tmpdir, "file.txt")
+        # poor man's touch
+        with open(file_name, "w") as txt_file:
+            txt_file.write('')
+
+        with self.assertRaises(ValueError) as val_err:
+            py2pack.utils._get_archive_filelist(file_name)
+
+        self.assertIn(file_name, str(val_err.exception))
+        self.assertIn("Not a tar or zip file", str(val_err.exception))


### PR DESCRIPTION
The major change proposed is that `_get_archive_filelist` now raises a `ValueError` instead of a `Exception`, which is (afaik) considered bad style.