### PR TITLE
Don't add BR on python-devel without thinking.

### DIFF
--- a/py2pack/templates/opensuse-legacy.spec
+++ b/py2pack/templates/opensuse-legacy.spec
@@ -23,7 +23,7 @@ Summary:        {{ summary_no_ending_dot|default(summary, true) }}
 Url:            {{ home_page }}
 Group:          Development/Languages/Python
 Source:         {{ source_url|replace(version, '%{version}') }}
-BuildRequires:  python-devel {%- if requires_python %} = {{ requires_python }} {% endif %}
+{%- if requires_python %} = {{ requires_python }} {% endif %}
 BuildRequires:  python-setuptools
 {%- if install_requires and install_requires is not none %}
 {%- for req in install_requires|sort %}

--- a/py2pack/templates/opensuse-legacy.spec
+++ b/py2pack/templates/opensuse-legacy.spec
@@ -23,7 +23,6 @@ Summary:        {{ summary_no_ending_dot|default(summary, true) }}
 Url:            {{ home_page }}
 Group:          Development/Languages/Python
 Source:         {{ source_url|replace(version, '%{version}') }}
-{%- if requires_python %} = {{ requires_python }} {% endif %}
 BuildRequires:  python-setuptools
 {%- if install_requires and install_requires is not none %}
 {%- for req in install_requires|sort %}

--- a/py2pack/templates/opensuse.spec
+++ b/py2pack/templates/opensuse.spec
@@ -25,7 +25,6 @@ Url:            {{ home_page }}
 Group:          Development/Languages/Python
 Source:         {{ source_url|replace(version, '%{version}') }}
 BuildRequires:  python-rpm-macros
-BuildRequires:  %{python_module devel}
 BuildRequires:  %{python_module setuptools}
 {%- if setup_requires and setup_requires is not none %}
 {%- for req in setup_requires|sort %}

--- a/test/examples/py2pack-opensuse-legacy.spec
+++ b/test/examples/py2pack-opensuse-legacy.spec
@@ -23,7 +23,6 @@ Summary:        Generate distribution packages from PyPI
 Url:            http://github.com/openSUSE/py2pack
 Group:          Development/Languages/Python
 Source:         https://files.pythonhosted.org/packages/source/p/py2pack/py2pack-%{version}.tar.gz
-BuildRequires:  python-devel
 BuildRequires:  python-setuptools
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 BuildArch:      noarch

--- a/test/examples/py2pack-opensuse.spec
+++ b/test/examples/py2pack-opensuse.spec
@@ -25,7 +25,6 @@ Url:            http://github.com/openSUSE/py2pack
 Group:          Development/Languages/Python
 Source:         https://files.pythonhosted.org/packages/source/p/py2pack/py2pack-%{version}.tar.gz
 BuildRequires:  python-rpm-macros
-BuildRequires:  %{python_module devel}
 BuildRequires:  %{python_module setuptools}
 BuildRequires:  fdupes
 BuildArch:      noarch


### PR DESCRIPTION
python*devel is required mostly for the building of architecture
dependent packages. It is wrong to add them in the default template, so
people blindly add them to all their python-related spec files.