### PR TITLE
Make template compatible with spec-cleaner

### DIFF
--- a/py2pack/templates/fedora.spec
+++ b/py2pack/templates/fedora.spec
@@ -7,10 +7,10 @@
 Name:           python-{{ name }}
 Version:        {{ version }}
 Release:        0
-Url:            {{ home_page }}
 Summary:        {{ summary }}
 License:        {{ license }}
 Group:          Development/Languages/Python
+URL:            {{ home_page }}
 Source:         {{ source_url|replace(version, '%{version}') }}
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 BuildRequires:  python-devel {%- if requires_python %} = {{ requires_python }} {% endif %}

--- a/py2pack/templates/opensuse-legacy.spec
+++ b/py2pack/templates/opensuse-legacy.spec
@@ -12,16 +12,16 @@
 # license that conforms to the Open Source Definition (Version 1.9)
 # published by the Open Source Initiative.
 
-# Please submit bugfixes or comments via http://bugs.opensuse.org/
+# Please submit bugfixes or comments via https://bugs.opensuse.org/
 
 
 Name:           python-{{ name }}
 Version:        {{ version }}
 Release:        0
-License:        {{ license }}
 Summary:        {{ summary_no_ending_dot|default(summary, true) }}
-Url:            {{ home_page }}
+License:        {{ license }}
 Group:          Development/Languages/Python
+URL:            {{ home_page }}
 Source:         {{ source_url|replace(version, '%{version}') }}
 BuildRequires:  python-setuptools
 {%- if install_requires and install_requires is not none %}

--- a/py2pack/templates/opensuse.spec
+++ b/py2pack/templates/opensuse.spec
@@ -12,17 +12,17 @@
 # license that conforms to the Open Source Definition (Version 1.9)
 # published by the Open Source Initiative.
 
-# Please submit bugfixes or comments via http://bugs.opensuse.org/
+# Please submit bugfixes or comments via https://bugs.opensuse.org/
 
 
 %{?!python_module:%define python_module() python-%{**} python3-%{**}}
 Name:           python-{{ name }}
 Version:        {{ version }}
 Release:        0
-License:        {{ license }}
 Summary:        {{ summary_no_ending_dot|default(summary, true) }}
-Url:            {{ home_page }}
+License:        {{ license }}
 Group:          Development/Languages/Python
+URL:            {{ home_page }}
 Source:         {{ source_url|replace(version, '%{version}') }}
 BuildRequires:  python-rpm-macros
 BuildRequires:  %{python_module setuptools}
@@ -64,7 +64,6 @@ Suggests:       python-{{ req }}
 {%- if not has_ext_modules %}
 BuildArch:      noarch
 {%- endif %}
-
 %python_subpackages
 
 %description

--- a/test/examples/py2pack-fedora.spec
+++ b/test/examples/py2pack-fedora.spec
@@ -1,16 +1,16 @@
 #
 # spec file for package python-py2pack
 #
-# Copyright (c) 2018 __USER__.
+# Copyright (c) 2019 __USER__.
 #
 
 Name:           python-py2pack
 Version:        0.8.0
 Release:        0
-Url:            http://github.com/openSUSE/py2pack
 Summary:        Generate distribution packages from PyPI
 License:        Apache-2.0
 Group:          Development/Languages/Python
+URL:            http://github.com/openSUSE/py2pack
 Source:         https://files.pythonhosted.org/packages/source/p/py2pack/py2pack-%{version}.tar.gz
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 BuildRequires:  python-devel

--- a/test/examples/py2pack-opensuse-legacy.spec
+++ b/test/examples/py2pack-opensuse-legacy.spec
@@ -12,16 +12,16 @@
 # license that conforms to the Open Source Definition (Version 1.9)
 # published by the Open Source Initiative.
 
-# Please submit bugfixes or comments via http://bugs.opensuse.org/
+# Please submit bugfixes or comments via https://bugs.opensuse.org/
 
 
 Name:           python-py2pack
 Version:        0.8.0
 Release:        0
-License:        Apache-2.0
 Summary:        Generate distribution packages from PyPI
-Url:            http://github.com/openSUSE/py2pack
+License:        Apache-2.0
 Group:          Development/Languages/Python
+URL:            http://github.com/openSUSE/py2pack
 Source:         https://files.pythonhosted.org/packages/source/p/py2pack/py2pack-%{version}.tar.gz
 BuildRequires:  python-setuptools
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/test/examples/py2pack-opensuse-legacy.spec
+++ b/test/examples/py2pack-opensuse-legacy.spec
@@ -1,7 +1,7 @@
 #
 # spec file for package python-py2pack
 #
-# Copyright (c) 2018 SUSE LINUX GmbH, Nuernberg, Germany.
+# Copyright (c) 2019 SUSE LINUX GmbH, Nuernberg, Germany.
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed

--- a/test/examples/py2pack-opensuse.spec
+++ b/test/examples/py2pack-opensuse.spec
@@ -12,23 +12,22 @@
 # license that conforms to the Open Source Definition (Version 1.9)
 # published by the Open Source Initiative.
 
-# Please submit bugfixes or comments via http://bugs.opensuse.org/
+# Please submit bugfixes or comments via https://bugs.opensuse.org/
 
 
 %{?!python_module:%define python_module() python-%{**} python3-%{**}}
 Name:           python-py2pack
 Version:        0.8.0
 Release:        0
-License:        Apache-2.0
 Summary:        Generate distribution packages from PyPI
-Url:            http://github.com/openSUSE/py2pack
+License:        Apache-2.0
 Group:          Development/Languages/Python
+URL:            http://github.com/openSUSE/py2pack
 Source:         https://files.pythonhosted.org/packages/source/p/py2pack/py2pack-%{version}.tar.gz
 BuildRequires:  python-rpm-macros
 BuildRequires:  %{python_module setuptools}
 BuildRequires:  fdupes
 BuildArch:      noarch
-
 %python_subpackages
 
 %description

--- a/test/examples/py2pack-opensuse.spec
+++ b/test/examples/py2pack-opensuse.spec
@@ -1,7 +1,7 @@
 #
 # spec file for package python-py2pack
 #
-# Copyright (c) 2018 SUSE LINUX GmbH, Nuernberg, Germany.
+# Copyright (c) 2019 SUSE LINUX GmbH, Nuernberg, Germany.
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed


### PR DESCRIPTION
When I call py2pack generate (some name) and spec-cleaner after that, the spec-cleaner makes some changes. Let us generate files which are "correct" according to spec-cleaner.