### PR TITLE
Fix date in test examples

### DIFF
--- a/test/examples/py2pack-fedora.spec
+++ b/test/examples/py2pack-fedora.spec
@@ -1,7 +1,7 @@
 #
 # spec file for package python-py2pack
 #
-# Copyright (c) 2018 __USER__.
+# Copyright (c) 2019 __USER__.
 #
 
 Name:           python-py2pack

--- a/test/examples/py2pack-opensuse-legacy.spec
+++ b/test/examples/py2pack-opensuse-legacy.spec
@@ -1,7 +1,7 @@
 #
 # spec file for package python-py2pack
 #
-# Copyright (c) 2018 SUSE LINUX GmbH, Nuernberg, Germany.
+# Copyright (c) 2019 SUSE LINUX GmbH, Nuernberg, Germany.
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed

--- a/test/examples/py2pack-opensuse.spec
+++ b/test/examples/py2pack-opensuse.spec
@@ -1,7 +1,7 @@
 #
 # spec file for package python-py2pack
 #
-# Copyright (c) 2018 SUSE LINUX GmbH, Nuernberg, Germany.
+# Copyright (c) 2019 SUSE LINUX GmbH, Nuernberg, Germany.
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed


### PR DESCRIPTION
It's 2019 now so the tests fail. There might be a better fix but this
works for now (and the rest of the year).