### PR TITLE
license is UNKNOWN if nothing determined

### DIFF
--- a/py2pack/__init__.py
+++ b/py2pack/__init__.py
@@ -203,7 +203,7 @@ def _normalize_license(data):
         else:
             data['license'] = "%s (FIXME:No SPDX)" % (license)
     else:
-        data['license'] = ""
+        data['license'] = "FIXME-UNKNOWN"
 
 
 def _prepare_template_env(template_dir):

--- a/test/test_py2pack.py
+++ b/test/test_py2pack.py
@@ -65,9 +65,9 @@ class Py2packTestCase(unittest.TestCase):
         self.assertEqual(url["packagetype"], "sdist")
 
     @data(
-        (None, [], ""),
+        (None, [], "FIXME-UNKNOWN"),
         ("Apache-2.0", [], "Apache-2.0"),
-        ("", [], ""),
+        ("", [], "FIXME-UNKNOWN"),
         ("Apache 2.0", [], "Apache-2.0"),
         ("", ["License :: OSI Approved :: Apache Software License"], "Apache-2.0"),
         ("BSD", [], "BSD (FIXME:No SPDX)"),


### PR DESCRIPTION
set license field to UNKNOWN instead if empty string to prevent silent errors
fixes openSUSE/py2pack#119