### PR TITLE
JSON API for metadata

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,6 @@ matrix:
     env: TOX_ENV=py38
   - python: 3.8
     env: TOX_ENV=docs
-  - python: 2.7
-    env: TOX_ENV=py27
   - python: 3.6
     env: TOX_ENV=py36
 install:

--- a/py2pack/__init__.py
+++ b/py2pack/__init__.py
@@ -57,6 +57,7 @@ def pypi_json(project, release=None):
     r = requests.get('https://pypi.org/pypi/{}{}/json'.format(project, version))
     return r.json()
 
+
 def _get_template_dirs():
     """existing directories where to search for jinja2 templates. The order
     is important. The first found template from the first found dir wins!"""
@@ -246,7 +247,7 @@ def generate(args):
     tarball_file = glob.glob("{0}-{1}.*".format(args.name, args.version))
     # also check tarball files with underscore. Some packages have a name with
     # a '-' or '.' but the tarball name has a '_' . Eg the package os-faults
-    tr = str.maketrans('-.','__')
+    tr = str.maketrans('-.', '__')
     tarball_file += glob.glob("{0}-{1}.*".format(args.name.translate(tr),
                                                  args.version))
     if tarball_file:                                                        # get some more info from that

--- a/py2pack/requires.py
+++ b/py2pack/requires.py
@@ -25,13 +25,10 @@ For further information concerning requirements (and markers), see `PEP 508
 <https://www.python.org/dev/peps/pep-0440/>`
 """
 
-from __future__ import absolute_import
-from __future__ import print_function
 from typing import List, Optional  # noqa: F401, pylint: disable=unused-import
 import sys
 
 import pkg_resources
-from six.moves import map
 
 
 def _requirement_filter_by_marker(req):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 Jinja2
 setuptools
-six
 metaextract
 typing;python_version<'3.5'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 Jinja2
 setuptools
 metaextract
+requests
 typing;python_version<'3.5'

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,7 +14,6 @@ classifier =
     Intended Audience :: System Administrators
     License :: OSI Approved :: Apache Software License
     Operating System :: POSIX
-    Programming Language :: Python :: 2
     Programming Language :: Python :: 3
     Topic :: Software Development :: Code Generators
     Topic :: Software Development :: Pre-processors

--- a/test/test_py2pack.py
+++ b/test/test_py2pack.py
@@ -47,7 +47,7 @@ class Py2packTestCase(unittest.TestCase):
                          expected_url)
 
     def test_list(self):
-        py2pack.list(self.args)
+        py2pack.list_packages(self.args)
 
     def test_search(self):
         py2pack.search(self.args)
@@ -56,6 +56,7 @@ class Py2packTestCase(unittest.TestCase):
         py2pack.show(self.args)
 
     def test_newest_download_url(self):
+        py2pack.fetch_data(self.args)
         url = py2pack.newest_download_url(self.args)
         self.assertTrue("url" in url)
         self.assertTrue("filename" in url)

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py36,py38,py39,pep8,cover
+envlist = py36,py38,py39,pep8,cover
 
 [testenv]
 usedevelop = True


### PR DESCRIPTION
Fetching the metadata only once and using the recommended JSON API mitigates #133.

I also killed the Python 2 shims with six and fixed the override of the builtin `list()` function.