### PR TITLE
remove outdated install instructions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -20,7 +20,7 @@ To install py2pack from the `Python Package Index`_, simply:
 
     $ pip install py2pack
 
-Lastly, you can check your distro of choice if they provide packages.
+You can also check your distro of choice if they provide packages.
 For openSUSE Tumbleweed and Leap 15.X, you can
 
 .. code-block:: bash
@@ -124,4 +124,3 @@ on your system.
 .. _`the repository`: https://github.com/openSUSE/py2pack
 .. _`pytest`: https://github.com/pytest-dev/pytest
 .. _`tox`: http://testrun.org/tox
-

--- a/README.rst
+++ b/README.rst
@@ -20,20 +20,12 @@ To install py2pack from the `Python Package Index`_, simply:
 
     $ pip install py2pack
 
-Or, if you absolutely must:
+Lastly, you can check your distro of choice if they provide packages.
+For openSUSE Tumbleweed and Leap 15.X, you can
 
 .. code-block:: bash
 
-    $ easy_install py2pack
-
-But, you really shouldn't do that. Lastly, you can check your distro of choice
-if they provide packages. For openSUSE, you can find packages in the `Open
-Build Service`_ for all releases. If you happen to use openSUSE:Factory (the
-rolling release / development version), simply:
-
-.. code-block:: bash
-
-    $ sudo zypper install python-py2pack
+    $ sudo zypper install python3-py2pack
 
 
 Usage


### PR DESCRIPTION
easy_install is completely deprecated.

python2 packages on openSUSE are not functional anymore. Avoid confusions like https://github.com/openSUSE/py2pack/issues/140#issuecomment-822038210
