### PR TITLE
templates: collect generator output to list before adding to another list

### DIFF
--- a/py2pack/templates/opensuse.spec
+++ b/py2pack/templates/opensuse.spec
@@ -81,7 +81,7 @@ export CFLAGS="%{optflags}"
 %install
 %python_install
 {%- set scripts_or_console_scripts = (
-            (scripts|map('basename') if scripts and scripts is not none else []) +
+            (scripts|map('basename')|list if scripts and scripts is not none else []) +
             (console_scripts if console_scripts and console_scripts is not none else [])) %}
 {%- for script in scripts_or_console_scripts %}
 %python_clone -a %{buildroot}%{_bindir}/{{ script }}


### PR DESCRIPTION
When trying to generate a spec for [git-machete](https://github.com/VirtusLab/git-machete) I get:

```
$ py2pack generate git-machete -f git-machete.spec
generating spec file for git-machete...
Traceback (most recent call last):
  File "/usr/bin/py2pack", line 10, in <module>
    sys.exit(main())
  File "/usr/lib/python3.8/site-packages/py2pack/__init__.py", line 365, in main
    args.func(args)
  File "/usr/lib/python3.8/site-packages/py2pack/__init__.py", line 264, in generate
    result = template.render(data).encode('utf-8')                          # render template and encode properly
  File "/usr/lib/python3.8/site-packages/jinja2/environment.py", line 1090, in render
    self.environment.handle_exception()
  File "/usr/lib/python3.8/site-packages/jinja2/environment.py", line 832, in handle_exception
    reraise(*rewrite_traceback_stack(source=source))
  File "/usr/lib/python3.8/site-packages/jinja2/_compat.py", line 28, in reraise
    raise value.with_traceback(tb)
  File "/usr/lib/python3.8/site-packages/py2pack/templates/opensuse.spec", line 83, in top-level template code
    {%- set scripts_or_console_scripts = (
TypeError: unsupported operand type(s) for +: 'generator' and 'list'
```

Turns out the, setup.py declares scripts=['git-machete'], which makes jinja2 try
running an equivalent of `map(os.path.basename, scripts) + []`.
