### PR TITLE
Use package name from PyPI for tarball name and warn if setup.py could not be run

### DIFF
--- a/py2pack/__init__.py
+++ b/py2pack/__init__.py
@@ -256,7 +256,12 @@ def generate(args):
         tarball_file += glob.glob("{0}-{1}.*".format(name.translate(tr),
                                                      args.version))
     if tarball_file:                                                        # get some more info from that
-        _augment_data_from_tarball(args, tarball_file[0], data)
+        try:
+            _augment_data_from_tarball(args, tarball_file[0], data)
+        except Exception as exc:
+            warnings.warn("Could not get information from tarball {}: {}. Valuable "
+                          "information for the generation might be missing."
+                          .format(tarball_file[0], exc))
     else:
         warnings.warn("No tarball for {} in version {} found. Valuable "
                       "information for the generation might be missing."

--- a/py2pack/__init__.py
+++ b/py2pack/__init__.py
@@ -245,12 +245,16 @@ def generate(args):
     data['user_name'] = pwd.getpwuid(os.getuid())[4]                        # set system user (packager)
     data['summary_no_ending_dot'] = re.sub(r'(.*)\.', r'\g<1>', data.get('summary', ""))
 
-    tarball_file = glob.glob("{0}-{1}.*".format(args.name, args.version))
-    # also check tarball files with underscore. Some packages have a name with
-    # a '-' or '.' but the tarball name has a '_' . Eg the package os-faults
-    tr = str.maketrans('-.', '__')
-    tarball_file += glob.glob("{0}-{1}.*".format(args.name.translate(tr),
-                                                 args.version))
+    # If package name supplied on command line differs in case from PyPI's one
+    # then package archive will be fetched but the name will be the one from PyPI.
+    # Eg. send2trash vs Send2Trash. Check that.
+    for name in (args.name, data['name']):
+        tarball_file = glob.glob("{0}-{1}.*".format(name, args.version))
+        # also check tarball files with underscore. Some packages have a name with
+        # a '-' or '.' but the tarball name has a '_' . Eg the package os-faults
+        tr = str.maketrans('-.', '__')
+        tarball_file += glob.glob("{0}-{1}.*".format(name.translate(tr),
+                                                     args.version))
     if tarball_file:                                                        # get some more info from that
         _augment_data_from_tarball(args, tarball_file[0], data)
     else:


### PR DESCRIPTION
Fix #148:
If package name on PyPI differs in case from what was supplied on the
command line then generate can not find tarball archive if it's name was
constructed using what was supplied on the command line.

Fix #150:
If setup.py is missing in archive (ex. PyQt5 package) or some dependency
needed to run setup.py is missing (ex. pymssql and Cython is missing) then
warn user and continue the same way as when archive is missing.