### PR TITLE
openSUSE teample: add package name to sitelib path

### DIFF
--- a/py2pack/templates/opensuse.spec
+++ b/py2pack/templates/opensuse.spec
@@ -122,9 +122,11 @@ CHOOSE: %pytest OR %pyunittest -v OR CUSTOM
 %python_alternative %{_bindir}/{{ script }}
 {%- endfor %}
 {%- if has_ext_modules %}
-%{python_sitearch}/*
+%{python_sitearch}/{{name}}
+%{python_sitearch}/{{name}}-%{version}*-info
 {%- else %}
-%{python_sitelib}/*
+%{python_sitelib}/{{name}}
+%{python_sitelib}/{{name}}-%{version}*-info
 {%- endif %}
 {%- if data_files and data_files is not none %}
 {%- for dir, files in data_files %}

--- a/test/examples/py2pack-opensuse-augmented.spec
+++ b/test/examples/py2pack-opensuse-augmented.spec
@@ -75,6 +75,7 @@ CHOOSE: %pytest OR %pyunittest -v OR CUSTOM
 %doc AUTHORS ChangeLog README.rst
 %license LICENSE
 %python_alternative %{_bindir}/py2pack
-%{python_sitelib}/*
+%{python_sitelib}/py2pack
+%{python_sitelib}/py2pack-%{version}*-info
 
 %changelog

--- a/test/examples/py2pack-opensuse.spec
+++ b/test/examples/py2pack-opensuse.spec
@@ -177,6 +177,7 @@ on your system.
 %python_expand %fdupes %{buildroot}%{$python_sitelib}
 
 %files %{python_files}
-%{python_sitelib}/*
+%{python_sitelib}/py2pack
+%{python_sitelib}/py2pack-%{version}*-info
 
 %changelog


### PR DESCRIPTION
Submissions to devel:languages:python are not accepted if
%{python_sitelib}/*
is used, so add the name of the library to produce a default value which
is permitted in openSUSE.
