### PR TITLE
Use %autosetup instead of %setup

### DIFF
--- a/py2pack/templates/opensuse-legacy.spec
+++ b/py2pack/templates/opensuse-legacy.spec
@@ -58,7 +58,7 @@ BuildArch:      noarch
 {{ description }}
 
 %prep
-%setup -q -n {{ name }}-%{version}
+%autosetup -p1 -n {{ name }}-%{version}
 
 %build
 {% if has_ext_modules %}CFLAGS="%{optflags}" {% endif %}python setup.py build

--- a/py2pack/templates/opensuse.spec
+++ b/py2pack/templates/opensuse.spec
@@ -70,7 +70,7 @@ BuildArch:      noarch
 {{ description }}
 
 %prep
-%setup -q -n {{ name }}-%{version}
+%autosetup -p1 -n {{ name }}-%{version}
 
 %build
 {%- if has_ext_modules %}

--- a/test/examples/py2pack-opensuse-augmented.spec
+++ b/test/examples/py2pack-opensuse-augmented.spec
@@ -52,7 +52,7 @@ BuildArch:      noarch
 Generate distribution packages from PyPI
 
 %prep
-%setup -q -n py2pack-%{version}
+%autosetup -p1 -n py2pack-%{version}
 
 %build
 %python_build

--- a/test/examples/py2pack-opensuse-legacy.spec
+++ b/test/examples/py2pack-opensuse-legacy.spec
@@ -163,7 +163,7 @@ on your system.
 .. _`tox`: http://testrun.org/tox
 
 %prep
-%setup -q -n py2pack-%{version}
+%autosetup -p1 -n py2pack-%{version}
 
 %build
 python setup.py build

--- a/test/examples/py2pack-opensuse.spec
+++ b/test/examples/py2pack-opensuse.spec
@@ -167,7 +167,7 @@ on your system.
 .. _`tox`: http://testrun.org/tox
 
 %prep
-%setup -q -n py2pack-%{version}
+%autosetup -p1 -n py2pack-%{version}
 
 %build
 %python_build


### PR DESCRIPTION
This patch replaces the use of %setup with %autosetup so patches will be applied automatically and there's no need to add manual call to %patch for each one.

Fix #163