### PR TITLE
Remove python_module definition macro

### DIFF
--- a/py2pack/templates/opensuse.spec
+++ b/py2pack/templates/opensuse.spec
@@ -16,7 +16,6 @@
 #
 
 
-%{?!python_module:%define python_module() python-%{**} python3-%{**}}
 Name:           python-{{ name }}
 Version:        {{ version }}
 Release:        0

--- a/test/examples/py2pack-opensuse-augmented.spec
+++ b/test/examples/py2pack-opensuse-augmented.spec
@@ -16,7 +16,6 @@
 #
 
 
-%{?!python_module:%define python_module() python-%{**} python3-%{**}}
 Name:           python-py2pack
 Version:        0.8.5
 Release:        0

--- a/test/examples/py2pack-opensuse.spec
+++ b/test/examples/py2pack-opensuse.spec
@@ -16,7 +16,6 @@
 #
 
 
-%{?!python_module:%define python_module() python-%{**} python3-%{**}}
 Name:           python-py2pack
 Version:        0.8.5
 Release:        0


### PR DESCRIPTION
The python_module macro is present in recent versions of python-rpm-macros and this line is not needed anymore.