### PR TITLE
Fix default generated spec filename

### DIFF
--- a/py2pack/__init__.py
+++ b/py2pack/__init__.py
@@ -234,7 +234,7 @@ def generate(args):
     if not args.template:
         args.template = file_template_list()[0]
     if not args.filename:
-        args.filename = args.name + '.' + args.template.rsplit('.', 1)[1]   # take template file ending
+        args.filename = "python-" + args.name + '.' + args.template.rsplit('.', 1)[1]   # take template file ending
     print('generating spec file for {0}...'.format(args.name))
     data = args.fetched_data['info']
     durl = newest_download_url(args)


### PR DESCRIPTION
By default package python-<packagename> is generated to <packagename>.spec

Add the python- prefix to default spec filename as well.

This is not a complete fix: the python prefix may or may not be required depending on package type. However, this goes from 100% wrong to mostly correct.

Fixes: #94

Signed-off-by: Michal Suchanek <msuchanek@suse.de>