### PR TITLE
Use and parse PEP517 backend data

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -10,7 +10,7 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                python-version: [3.8, 3.9, "3.10", 3.11]
+                python-version: ["3.8", "3.9", "3.10", "3.11"]
 
         steps:
             - uses: actions/checkout@v2

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ setuptools
 metaextract
 requests
 pypi-search
+tomli ; python_version < '3.11'

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,11 +2,11 @@
 name = py2pack
 summary = Generate distribution packages from PyPI
 version = 0.8.7
-description-file =
+description_file =
     README.rst
 author = Sascha Peilicke, Thomas Bechtold
-author-email = sascha@peilicke.de, thomasbechtold@jpberlin.de
-home-page = http://github.com/openSUSE/py2pack
+author_email = sascha@peilicke.de, thomasbechtold@jpberlin.de
+home_page = http://github.com/openSUSE/py2pack
 classifier =
     Development Status :: 4 - Beta
     Environment :: Console

--- a/test/examples/py2pack-opensuse-augmented.spec
+++ b/test/examples/py2pack-opensuse-augmented.spec
@@ -24,12 +24,13 @@ License:        Apache-2.0
 URL:            http://github.com/openSUSE/py2pack
 Source:         https://files.pythonhosted.org/packages/source/p/py2pack/py2pack-%{version}.tar.gz
 BuildRequires:  python-rpm-macros
-BuildRequires:  %{python_module setuptools}
 BuildRequires:  %{python_module pbr >= 1.8}
+BuildRequires:  %{python_module pip}
+BuildRequires:  %{python_module setuptools}
+BuildRequires:  %{python_module wheel}
 # SECTION test requirements
 BuildRequires:  %{python_module Jinja2}
 BuildRequires:  %{python_module metaextract}
-BuildRequires:  %{python_module setuptools}
 BuildRequires:  %{python_module six}
 BuildRequires:  %{python_module coverage}
 BuildRequires:  %{python_module ddt}
@@ -54,10 +55,10 @@ Generate distribution packages from PyPI
 %autosetup -p1 -n py2pack-%{version}
 
 %build
-%python_build
+%pyproject_wheel
 
 %install
-%python_install
+%pyproject_install
 %python_clone -a %{buildroot}%{_bindir}/py2pack
 %python_expand %fdupes %{buildroot}%{$python_sitelib}
 
@@ -75,6 +76,6 @@ CHOOSE: %pytest OR %pyunittest -v OR CUSTOM
 %license LICENSE
 %python_alternative %{_bindir}/py2pack
 %{python_sitelib}/py2pack
-%{python_sitelib}/py2pack-%{version}*-info
+%{python_sitelib}/py2pack-%{version}.dist-info
 
 %changelog

--- a/test/examples/py2pack-opensuse.spec
+++ b/test/examples/py2pack-opensuse.spec
@@ -24,7 +24,7 @@ License:        Apache-2.0
 URL:            http://github.com/openSUSE/py2pack
 Source:         https://files.pythonhosted.org/packages/source/p/py2pack/py2pack-%{version}.tar.gz
 BuildRequires:  python-rpm-macros
-BuildRequires:  %{python_module setuptools}
+BuildRequires:  %{python_module pip}
 BuildRequires:  fdupes
 BuildArch:      noarch
 %python_subpackages
@@ -169,14 +169,14 @@ on your system.
 %autosetup -p1 -n py2pack-%{version}
 
 %build
-%python_build
+%pyproject_wheel
 
 %install
-%python_install
+%pyproject_install
 %python_expand %fdupes %{buildroot}%{$python_sitelib}
 
 %files %{python_files}
 %{python_sitelib}/py2pack
-%{python_sitelib}/py2pack-%{version}*-info
+%{python_sitelib}/py2pack-%{version}.dist-info
 
 %changelog

--- a/test/test_py2pack.py
+++ b/test/test_py2pack.py
@@ -104,38 +104,81 @@ class Py2packTestCase(unittest.TestCase):
     @data(
         (
             {'install_requires': ["pywin32>=1.0;sys_platform=='win32'", 'monotonic>=0.1 #comment']},
-            {'install_requires': ['monotonic >= 0.1']},
+            {'build_requires': ['setuptools', 'wheel'],
+             'install_requires': ['monotonic >= 0.1']},
         ),
         (
             {'install_requires': 'six  >=1.9,!=1.0  # comment\nfoobar>=0.1,>=0.5'},
-            {'install_requires': ['six >= 1.9', 'foobar >= 0.1']}
+            {'build_requires': ['setuptools', 'wheel'],
+             'install_requires': ['six >= 1.9', 'foobar >= 0.1']}
         ),
         (
             {'setup_requires': 'six  >=1.9,!=1.0  # comment\nfoobar>=0.1,>=0.5'},
-            {'setup_requires': ['six >= 1.9', 'foobar >= 0.1']}
+            {'build_requires': ['setuptools', 'wheel', 'six >= 1.9', 'foobar >= 0.1']}
         ),
         (
             {'tests_require': ['six  >=1.9', 'foobar>=0.1,>=0.5']},
-            {'tests_require': ['six >= 1.9', 'foobar >= 0.1']}
+            {'build_requires': ['setuptools', 'wheel'],
+             'tests_require': ['six >= 1.9', 'foobar >= 0.1']}
         ),
         (
             {'tests_require': 'six  >=1.9\nfoobar>=0.1,>=0.5'},
-            {'tests_require': ['six >= 1.9', 'foobar >= 0.1']}
+            {'build_requires': ['setuptools', 'wheel'],
+             'tests_require': ['six >= 1.9', 'foobar >= 0.1']}
         ),
         (
             {'extras_require': {'extra1': ['foobar<=3.0, >= 2.1']}},
-            {'extras_require': {'extra1': ['foobar >= 2.1']}}
+            {'build_requires': ['setuptools', 'wheel'],
+             'extras_require': {'extra1': ['foobar >= 2.1']}}
         ),
         (
             {'extras_require': {'extra1': 'foobar<=3.0, >= 2.1\ntest1  # comment',
                                 'extra2': ['test2']}},
-            {'extras_require': {'extra1': ['foobar >= 2.1', 'test1'],
+            {'build_requires': ['setuptools', 'wheel'],
+             'extras_require': {'extra1': ['foobar >= 2.1', 'test1'],
                                 'extra2': ['test2']}}
+        ),
+        (
+            {'build-system': {'requires': ['setuptools']},
+             'project': {'dependencies': ['foo', 'bar>=1', 'foobar>2,<3'],
+                         'optional-dependencies': {'extra': ['extra1', 'extra2 >2'],
+                                                   'test': ['pytest']},
+                         'scripts': {'cmd1': 'foo:main', 'cmd2': 'bar:cmd2'},
+                         'gui-scripts': {'gui': 'foo:mainview'}}},
+            {'build_requires': ['setuptools', 'wheel'],
+             'install_requires': ['foo', 'bar >= 1', 'foobar > 2'],
+             'extras_require': {'extra': ['extra1', 'extra2 > 2']},
+             'tests_require': ['pytest'],
+             'console_scripts': ['cmd1', 'cmd2', 'gui']}
+        ),
+        (
+            {'build-system': {'requires': ['flit_core']},
+             'tool': { 'flit': {
+                'metadata': {
+                    'requires': ['foo', 'bar>=1','foobar>2,<3'],
+                    'requires-extra': {'extra': ['extra1', 'extra2>2'],
+                                       'test': ['pytest']}},
+                'scripts': {'cmd': 'foo:main'}}}},
+            {'build_requires': ['flit_core'],
+             'install_requires': ['foo', 'bar >= 1', 'foobar > 2'],
+             'extras_require': {'extra': ['extra1', 'extra2 > 2']},
+             'tests_require': ['pytest'],
+             'console_scripts': ['cmd']}
+        ),
+        (
+            {'build-system': {'requires': ['hatchling']},
+             'project': {'dependencies': ['foo', 'bar>=1', 'foobar>2,<3']}},
+            {'build_requires': ['hatchling'],
+             'install_requires': ['foo', 'bar >= 1', 'foobar > 2']}
         ),
     )
     @unpack
-    def test_canonicalize_setup_data(self, data, expected_data):
-        py2pack._canonicalize_setup_data(data)
+    def test_canonicalize_setup_data(self, data, updated_data):
+        expected_data = data.copy()
+        expected_data.update(updated_data)
+        expected_data.pop("setup_requires", None)
+        py2pack._canonicalize_setup_data(data)    
+        self.maxDiff = None
         self.assertEqual(data, expected_data)
 
     @data(


### PR DESCRIPTION
Implements #104

`%python_install` (`pyhton3 setup.py install`) has been deprecated quite some time ago. The new way to go is `pyproject_install` with building the wheel before.

Parses pyproject.toml, supplemented by legacy setup.py parsed by metaextract.