### PR TITLE
Ensure that license_files is not None

### DIFF
--- a/py2pack/__init__.py
+++ b/py2pack/__init__.py
@@ -300,7 +300,7 @@ def _augment_data_from_tarball(args, filename, data):
                 data["doc_files"] = []
             data["doc_files"].append(_quote_shell_metacharacters(match_docs.group(1)))
         if match_license:
-            if "license_files" not in data:
+            if data.get("license_files", None) is None:
                 data["license_files"] = []
             data["license_files"].append(_quote_shell_metacharacters(match_license.group(1)))
         # Very broad check for testsuites


### PR DESCRIPTION
This patch makes sure that the data["license_files"] exists and is not None before trying to append files there.

Fix https://github.com/openSUSE/py2pack/issues/209