### PR TITLE
Version bump

### DIFF
--- a/py2pack/version.py
+++ b/py2pack/version.py
@@ -16,6 +16,6 @@
 # limitations under the License.
 
 # this one is read by hatch or hatchling during build
-__version__ = "0.9.0"
+__version__ = "0.9.1"
 
 version = __version__

--- a/test/examples/poetry-opensuse-augmented.spec
+++ b/test/examples/poetry-opensuse-augmented.spec
@@ -1,7 +1,7 @@
 #
 # spec file for package python-poetry
 #
-# Copyright (c) 2024 SUSE LLC
+# Copyright (c) __YEAR__ SUSE LLC
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed
@@ -21,7 +21,7 @@ Version:        1.5.1
 Release:        0
 Summary:        Python dependency management and packaging made easy
 License:        MIT
-URL:            https://python-poetry.org/
+URL:            None
 Source:         https://files.pythonhosted.org/packages/source/p/poetry/poetry-%{version}.tar.gz
 BuildRequires:  python-rpm-macros
 BuildRequires:  %{python_module pip}


### PR DESCRIPTION
It's time for a new release

See https://github.com/openSUSE/py2pack/issues/212

Changelog:
0.9.1:
* Don't crash on missing urls
* fix: sanitize summary only if it exists
* Use platformdirs module to find template directory paths.
* fix bug: AttributeError: 'Namespace' object has no attribute 'localfile' for fetch command
* Use build.project_wheel_metadata to extract metadata
* Fix no esp variable (utils.py)
* Fix new argument access and tests
* Add ability to generate .spec files from local PKG-INFO file
* Support project.urls.Repository to get homepage
* Replace deprecated PyPI XML API with Simple API
* close all connections: replace urllib with requests
* remove pkg_resources
* Migrate update spdx command from setuptools hook to hatch script, execute
* Migrate spdx file from pickle to json
* Switch from setuptools+pbr to hatch
