### PR TITLE
Drop search

### DIFF
--- a/py2pack/__init__.py
+++ b/py2pack/__init__.py
@@ -29,7 +29,6 @@ import sys
 import warnings
 
 import jinja2
-import pypi_search.search
 import requests
 from metaextract import utils as meta_utils
 
@@ -119,12 +118,6 @@ def list_packages(args=None):
     simplere = re.compile(r'<a href="/simple/.+">(.*)</a>')
     for package in simplere.findall(html):
         print(package)
-
-
-def search(args):
-    print('searching for package {0}...'.format(args.name))
-    for hit in pypi_search.search.find_packages(args.name):
-        print('found {0}-{1}'.format(hit['name'], hit['version']))
 
 
 def show(args):
@@ -479,10 +472,6 @@ def main():
 
     parser_list = subparsers.add_parser('list', help='list all packages on PyPI')
     parser_list.set_defaults(func=list_packages)
-
-    parser_search = subparsers.add_parser('search', help='search for packages on PyPI')
-    parser_search.add_argument('name', help='package name (with optional version)')
-    parser_search.set_defaults(func=search)
 
     parser_show = subparsers.add_parser('show', help='show metadata for package')
     parser_show.add_argument('name', help='package name')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,6 @@ dependencies = [
     "metaextract",
     "platformdirs",
     "packaging",
-    "pypi-search",
     "requests",
     "tomli; python_version < '3.11'",
 ]

--- a/test/test_py2pack.py
+++ b/test/test_py2pack.py
@@ -59,9 +59,6 @@ class Py2packTestCase(unittest.TestCase):
     def test_list(self):
         py2pack.list_packages(self.args)
 
-    def test_search(self):
-        py2pack.search(self.args)
-
     def test_show(self):
         py2pack.show(self.args)
 


### PR DESCRIPTION
XML-RPC search and pypi-search package are no longer available in pypi. Thesefore tests will always fail